### PR TITLE
Use sched_setattr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ data/
 *.svg
 
 trace.txt
+data.csv

--- a/examples/message_passing_example/src/main.cc
+++ b/examples/message_passing_example/src/main.cc
@@ -36,6 +36,7 @@ class RTApp : public cactus_rt::App {
 };
 
 int main() {
+  spdlog::set_level(spdlog::level::debug);
   RTApp app("data.csv");
 
   app.Start();

--- a/include/cactus_rt/cyclic_fifo_thread.h
+++ b/include/cactus_rt/cyclic_fifo_thread.h
@@ -36,7 +36,7 @@ class CyclicFifoThread : public Thread {
    */
   CyclicFifoThread(const std::string&  name,
                    int64_t             period_ns,
-                   int                 priority = 80,
+                   uint32_t            priority = 80,
                    std::vector<size_t> cpu_affinity = {},
                    size_t              stack_size = kDefaultStackSize)
       : Thread(name, priority, SCHED_FIFO, cpu_affinity, stack_size),

--- a/include/cactus_rt/linux/sched_ext.h
+++ b/include/cactus_rt/linux/sched_ext.h
@@ -1,0 +1,40 @@
+#ifndef CACTUS_RT_LINUX_SCHED_EXT_H_
+#define CACTUS_RT_LINUX_SCHED_EXT_H_
+
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#include <cstdint>
+
+struct sched_attr {
+  uint32_t size;
+
+  uint32_t sched_policy;
+  uint64_t sched_flags;
+
+  /* SCHED_NORMAL, SCHED_BATCH */
+  int32_t sched_nice;
+
+  /* SCHED_FIFO, SCHED_RR */
+  uint32_t sched_priority;
+
+  /* SCHED_DEADLINE (nsec) */
+  uint64_t sched_runtime;
+  uint64_t sched_deadline;
+  uint64_t sched_period;
+};
+
+inline int sched_setattr(pid_t                    pid,
+                         const struct sched_attr *attr,
+                         unsigned int             flags) {
+  return syscall(SYS_sched_setattr, pid, attr, flags);
+}
+
+inline int sched_getattr(pid_t              pid,
+                         struct sched_attr *attr,
+                         unsigned int       size,
+                         unsigned int       flags) {
+  return syscall(SYS_sched_getattr, pid, attr, size, flags);
+}
+
+#endif

--- a/include/cactus_rt/thread.h
+++ b/include/cactus_rt/thread.h
@@ -11,14 +11,16 @@
 #include <string>
 #include <vector>
 
+#include "linux/sched_ext.h"
+
 namespace cactus_rt {
 
 constexpr size_t kDefaultStackSize = 8 * 1024 * 1024;  // 8MB
 
 class Thread {
   std::string         name_;
-  int                 priority_;
-  int                 policy_;
+  uint32_t            priority_;
+  uint32_t            policy_;
   std::vector<size_t> cpu_affinity_;
   size_t              stack_size_;
 
@@ -40,8 +42,8 @@ class Thread {
 
  public:
   Thread(const std::string&  name,
-         int                 priority,
-         int                 policy = SCHED_OTHER,
+         uint32_t            priority,
+         uint32_t            policy = SCHED_OTHER,
          std::vector<size_t> cpu_affinity = {},
          size_t              stack_size = kDefaultStackSize)
       : name_(name),

--- a/src/latency_tracker.cc
+++ b/src/latency_tracker.cc
@@ -19,6 +19,7 @@ void LatencyTracker::RecordValue(double v) noexcept {
 }
 
 void LatencyTracker::DumpToLogger() const {
+  spdlog::set_level(spdlog::level::debug);
   SPDLOG_DEBUG("min: {:.4f} | mean: {:.4f} | max: {:.4f} | count: {}", min_, mean_, max_, count_);
 }
 }  // namespace cactus_rt


### PR DESCRIPTION
Use sched_setattr for eventual SCHED_DEADLINE support

Also includes various minor changes:
- Add data.csv (generated from message_passing_example) to .gitignore
- Set log level in the examples to enable printing