### PR TITLE
Refactored App to start threads automatically

### DIFF
--- a/examples/lttng_ust_example/src/main.cc
+++ b/examples/lttng_ust_example/src/main.cc
@@ -30,15 +30,8 @@ class RTApp : public cactus_rt::App {
   CyclicThread cyclic_thread_;
 
  public:
-  void Start() final {
-    cactus_rt::App::Start();
-    auto monotonic_now = cactus_rt::NowNs();
-    auto wall_now = cactus_rt::WallNowNs();
-    cyclic_thread_.Start(monotonic_now, wall_now);
-  }
-
-  void Join() {
-    cyclic_thread_.Join();
+  RTApp() {
+    RegisterThread(cyclic_thread_);
   }
 
   void Stop() {
@@ -52,7 +45,7 @@ int main() {
 
   RTApp app;
 
-  constexpr unsigned int time = 60;
+  constexpr unsigned int time = 30;
   SPDLOG_INFO("Running for {}s", time);
   app.Start();
   sleep(time);

--- a/examples/message_passing_example/include/data_logger.h
+++ b/examples/message_passing_example/include/data_logger.h
@@ -21,9 +21,8 @@ struct OutputData {
 class DataLogger : public cactus_rt::Thread<cactus_rt::schedulers::Other> {
   constexpr static int kQueueCapacity = 8 * 1024;  // This is over 8 seconds of data. Should never be full.
 
-  std::atomic_bool should_stop_;
-  int64_t          period_us_;
-  double           write_data_interval_seconds_;
+  int64_t period_us_;
+  double  write_data_interval_seconds_;
 
   // https://www.boost.org/doc/libs/1_56_0/doc/html/boost/lockfree/spsc_queue.html
   // When full: reject additional push with returning false. This might be OK.
@@ -69,13 +68,6 @@ class DataLogger : public cactus_rt::Thread<cactus_rt::schedulers::Other> {
    * @returns success if the data is written into the buffer, false otherwise.
    */
   bool LogData(const OutputData& data) noexcept;
-
-  /**
-   * Requests the data logger to stop
-   */
-  void RequestStop() noexcept {
-    should_stop_.store(true);
-  }
 
   /**
    * Should only be called after the thread has joined, otherwise there's a

--- a/examples/message_passing_example/src/data_logger.cc
+++ b/examples/message_passing_example/src/data_logger.cc
@@ -10,7 +10,6 @@ DataLogger::DataLogger(const std::string& data_file_path,
                        int64_t            period_us,
                        double             write_data_interval_seconds)
     : Thread<cactus_rt::schedulers::Other>("DataLogger"),
-      should_stop_(false),
       period_us_(period_us),
       write_data_interval_seconds_(write_data_interval_seconds),
       data_fifo_push_failed_count_(0, 0) {
@@ -56,7 +55,7 @@ void DataLogger::Run() {
     // If there is data, we keep popping from the queue.
     if (no_data) {
       // If there is no data, then we can check if we should stop
-      if (should_stop_) {
+      if (this->StopRequested()) {
         break;
       }
 

--- a/examples/message_passing_example/src/main.cc
+++ b/examples/message_passing_example/src/main.cc
@@ -12,26 +12,14 @@ class RTApp : public cactus_rt::App {
   RTApp(const std::string& data_file_path) noexcept
       : data_logger_(data_file_path),
         rt_thread_(data_logger_, 1'000'000, std::vector<size_t>(), 30'000) {
+    RegisterThread(data_logger_);
+    RegisterThread(rt_thread_);
   }
 
-  void Start() final {
-    cactus_rt::App::Start();
-    auto monotonic_now = cactus_rt::NowNs();
-    auto wall_now = cactus_rt::WallNowNs();
-    data_logger_.Start(monotonic_now, wall_now);
-    rt_thread_.Start(monotonic_now, wall_now);
-  }
-
-  void Join() {
+  void Join() override {
     rt_thread_.Join();
     data_logger_.RequestStop();
     data_logger_.Join();
-  }
-
-  void Stop() {
-    rt_thread_.RequestStop();
-    data_logger_.RequestStop();
-    Join();
   }
 };
 

--- a/examples/simple_deadline_example/main.cc
+++ b/examples/simple_deadline_example/main.cc
@@ -23,15 +23,8 @@ class RTApp : public cactus_rt::App {
   MyDeadlineThread cyclic_thread_;
 
  public:
-  void Start() final {
-    cactus_rt::App::Start();
-    auto monotonic_now = cactus_rt::NowNs();
-    auto wall_now = cactus_rt::WallNowNs();
-    cyclic_thread_.Start(monotonic_now, wall_now);
-  }
-
-  void Join() {
-    cyclic_thread_.Join();
+  RTApp() {
+    RegisterThread(cyclic_thread_);
   }
 
   void Stop() {

--- a/examples/simple_example/main.cc
+++ b/examples/simple_example/main.cc
@@ -17,25 +17,16 @@ class CyclicThread : public cactus_rt::CyclicThread<cactus_rt::schedulers::Fifo>
 };
 
 class RTApp : public cactus_rt::App {
-  CyclicThread cyclic_thread_;
+  CyclicThread thread_;
 
  public:
-  RTApp(std::vector<size_t> cpu_affinity) : cyclic_thread_(cpu_affinity) {}
-
-  void Start() final {
-    cactus_rt::App::Start();
-    auto monotonic_now = cactus_rt::NowNs();
-    auto wall_now = cactus_rt::WallNowNs();
-    cyclic_thread_.Start(monotonic_now, wall_now);
-  }
-
-  void Join() {
-    cyclic_thread_.Join();
+  RTApp(std::vector<size_t> cpu_affinity) : thread_(cpu_affinity) {
+    RegisterThread(thread_);
   }
 
   void Stop() {
-    cyclic_thread_.RequestStop();
-    Join();
+    thread_.RequestStop();
+    thread_.Join();
   }
 };
 
@@ -44,7 +35,7 @@ int main() {
 
   RTApp app(std::vector<size_t>{2});
 
-  constexpr unsigned int time = 60;
+  constexpr unsigned int time = 5;
   SPDLOG_INFO("Testing latency for {}s", time);
   app.Start();
   sleep(time);

--- a/include/cactus_rt/app.h
+++ b/include/cactus_rt/app.h
@@ -1,31 +1,31 @@
-#ifndef CACTUS_RT_APP_H_
-#define CACTUS_RT_APP_H_
+#ifndef CACTUS_RT_APP2_H_
+#define CACTUS_RT_APP2_H_
 
 #include <cstddef>
 #include <cstdint>
+#include <map>
+#include <memory>
+
+#include "thread.h"
 
 namespace cactus_rt {
 class App {
+  /**
+   * Size of the heap to reserve in bytes.
+   */
   size_t heap_size_;
 
-  /**
-   * The start time of the application from the monotonic clock in nanoseconds.
-   */
-  int64_t start_monotonic_time_ns_;
-
-  /**
-   * The start time of the application from the realtime clock in nanoseconds.
-   * Do not ever use this for any real-time sensitive computations.
-   */
-  int64_t start_wall_time_ns_;
+  // Non-owning references to threads just to help with starting and joining the thrad.
+  std::vector<BaseThread*> threads_;
 
  public:
   /**
-   * Creates an instance of the RT app.
+   * Creates an instance of the RT app. The app should always be created before
+   * the threads as there are some global setup that can take place.
    *
    * @param heap_size The heap size to reserve in bytes. Defaults to 512MB.
    */
-  App(size_t heap_size = 512 * 1024 * 1024) : heap_size_(heap_size) {}
+  explicit App(size_t heap_size = 512 * 1024 * 1024) : heap_size_(heap_size) {}
   virtual ~App() = default;
 
   // Copy constructors
@@ -37,9 +37,28 @@ class App {
   App& operator=(App&&) noexcept = default;
 
   /**
-   * Starts the app by locking the memory and reserving the memory.
+   * @brief Registers a thread to be automatically started by the app. The start
+   * order of the threads are in the order of registration.
+   *
+   * @param thread A reference to the thread. Note that this function call does
+   * not assume ownership of the thread. Ensure the lifetime of the thread is at
+   * least as long as the lifetime of the App.
+   */
+  void RegisterThread(BaseThread& thread);
+
+  /**
+   * Starts the app by locking the memory and reserving the memory. Also start
+   * all the threads in registration order.
    */
   virtual void Start();
+
+  /**
+   * Joins all the threads in registration order.
+   *
+   * Override this if you want a different order of operation, or if you want to
+   * request stop on a thread after another one is done.
+   */
+  virtual void Join();
 
  protected:
   /**

--- a/include/cactus_rt/thread.h
+++ b/include/cactus_rt/thread.h
@@ -4,6 +4,7 @@
 #include <limits.h>  // For PTHREAD_STACK_MIN
 #include <pthread.h>
 
+#include <atomic>
 #include <cstring>
 #include <stdexcept>
 #include <string>
@@ -15,9 +16,54 @@ namespace cactus_rt {
 
 constexpr size_t kDefaultStackSize = 8 * 1024 * 1024;  // 8MB
 
+// Needed because the App needs to hold a list of threads that it can start them
+// automatically.  Have a templated thread won't work with that system.
+class BaseThread {
+  std::atomic_bool stop_requested_;
+
+ public:
+  virtual const std::string& Name() = 0;
+  virtual void               Start(int64_t start_monotonic_time_ns, int64_t start_wall_time_ns) = 0;
+  virtual int                Join() = 0;
+
+  virtual void RequestStop() noexcept {
+    stop_requested_ = true;
+  }
+
+  // The constructors and destructors are needed because we need to delete
+  // objects of type BaseThread polymorphically, through the map in the App class.
+  BaseThread() = default;
+  virtual ~BaseThread() = default;
+
+  // Copy constructors is not allowed
+  BaseThread(const BaseThread&) = delete;
+  BaseThread& operator=(const BaseThread&) = delete;
+
+  // Move constructors is allowed
+  BaseThread(BaseThread&&) noexcept = default;
+  BaseThread& operator=(BaseThread&&) noexcept = default;
+
+ protected:
+  /**
+   * @brief Check if stop has been requested
+   *
+   * @return true if stop is requested
+   */
+  bool StopRequested() const noexcept {
+    // Memory order relaxed is OK, because we don't really care when the signal
+    // arrives, we just care that it is arrived at some point.
+    //
+    // Also this could be used in a tight loop so we don't want to waste time when we don't need to.
+    //
+    // https://stackoverflow.com/questions/70581645/why-set-the-stop-flag-using-memory-order-seq-cst-if-you-check-it-with-memory
+    // TODO: possibly use std::stop_source and std::stop_token (C++20)
+    return stop_requested_.load(std::memory_order_relaxed);
+  }
+};
+
 // TODO: some docs
 template <typename SchedulerT>
-class Thread {
+class Thread : public BaseThread {
   std::string                 name_;
   typename SchedulerT::Config scheduler_config_;
   pthread_t                   thread_;
@@ -49,15 +95,9 @@ class Thread {
         // In case stack_size is 0...
         stack_size_(static_cast<size_t>(PTHREAD_STACK_MIN) + stack_size){};
 
-  virtual ~Thread() = default;
-
-  // Copy constructors
-  Thread(const Thread&) = delete;
-  Thread& operator=(const Thread&) = delete;
-
-  // Move constructors
-  Thread(Thread&&) noexcept = default;
-  Thread& operator=(Thread&&) noexcept = default;
+  const std::string& Name() override {
+    return name_;
+  }
 
   /**
    * Starts the thread in the background.
@@ -66,7 +106,7 @@ class Thread {
    * @param start_wall_time_ns should be the start time in nanoseconds for the realtime clock.
    */
 
-  void Start(int64_t start_monotonic_time_ns, int64_t start_wall_time_ns) {
+  void Start(int64_t start_monotonic_time_ns, int64_t start_wall_time_ns) override {
     start_monotonic_time_ns_ = start_monotonic_time_ns;
     start_wall_time_ns_ = start_wall_time_ns;
 
@@ -116,7 +156,7 @@ class Thread {
    *
    * @returns the return value of pthread_join
    */
-  int Join() const {
+  int Join() override {
     return pthread_join(thread_, nullptr);
   }
 


### PR DESCRIPTION
The `App` class now contains vector of pointer to `BaseThread` objects. This vector is populated with the `App::RegisterThread()` function. Since the `App` class holds a vector of pointers, the caller of `RegisterThread` must ensure the lifetime of the thread is at least as long as the lifetime of the app. In the example programs, this is accomplished by having the threads as member variables on the user-defined App object that derives from `cactus_rt::App`.

During `App::Start()`, the threads are started in registration order automatically. No more need to manually create a `App::Start()` function.

To enable this refactor, a `BaseThread` class has to be created as the current `Thread` class is a templated class (and thus cannot be directly used as the value type of a vector). Additionally, the `BaseThread` now implements functionality to request the thread to stop via an atomic stop flag so this code can be shared across all thread implementations. `CyclicThread` now checks this flag via the `BaseThread::StopRequested()`. We also use the `memory_order_relaxed` to check, as this is safe and slightly more efficient than using sequential consistency (default for atomics).

I've also considered to implement an `App::RequestStop()` function, but stopping order could be a problem so I've deferred that for later.