### PR TITLE
Iceoryx example

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
         run: docker/scripts/00-format.sh
 
       - name: Setup dependencies
-        run: sudo apt-get update && sudo apt-get install -y libspdlog-dev liblttng-ust-dev libboost-dev
+        run: sudo apt-get update && sudo apt-get install -y libspdlog-dev liblttng-ust-dev libboost-dev libacl1-dev
 
       - name: Build library
         run: docker/scripts/01-build.sh

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ data/
 
 trace.txt
 data.csv
+.vscode/settings.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,15 +62,15 @@ target_compile_options(cactus_rt
 if(${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME})
   include(CTest)
 
-  if (BUILD_TESTING)
-    add_subdirectory(tests)
-  endif()
-
   if (ENABLE_CLANG_TIDY)
-    find_program(CLANG_TIDY clang-tidy clang-tidy-14 clang-tidy-13 clang-tidy-12 clang-tidy-11)
-    set_target_properties(cactus_rt PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY})
+    find_program(CLANG_TIDY_PATH clang-tidy clang-tidy-14 clang-tidy-13 clang-tidy-12 clang-tidy-11)
+    set_target_properties(cactus_rt PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY_PATH})
   else()
     message(STATUS "Not running clang-tidy. Use ENABLE_CLANG_TIDY=ON to run clang-tidy.")
+  endif()
+
+  if (BUILD_TESTING)
+    add_subdirectory(tests)
   endif()
 
   if (ENABLE_EXAMPLES)
@@ -80,5 +80,6 @@ if(${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME})
     add_subdirectory(examples/mutex_example)
     add_subdirectory(examples/lttng_ust_example)
     add_subdirectory(examples/simple_deadline_example)
+    add_subdirectory(examples/iceoryx_example)
   endif()
 endif()

--- a/README.rst
+++ b/README.rst
@@ -85,11 +85,12 @@ Tested on Debian 10 and Ubuntu 20.04:
 
 .. code-block:: console
 
-   $ sudo apt install libspdlog-dev liblttng-ust-dev libboost-dev lttng-tools
+   $ sudo apt install libspdlog-dev liblttng-ust-dev libboost-dev lttng-tools libacl1-dev
 
 - ``liblttng-ust-dev`` is only used in ``lttng_ust_example``.
 - ``lttng-tools`` is used for tracing the ``lttng_ust_example``.
 - ``libboost-dev`` is only used for the lockfree queue in the ``message_passing_example``.
+- ``libacl1-dev`` is needed for iceoryx.
 
 Of course you also need a C++ compiler and cmake.
 

--- a/examples/iceoryx_example/CMakeLists.txt
+++ b/examples/iceoryx_example/CMakeLists.txt
@@ -1,0 +1,49 @@
+Include(FetchContent)
+
+set(FETCHCONTENT_QUIET FALSE)
+
+FetchContent_Declare(
+  iceoryx
+  GIT_REPOSITORY https://github.com/eclipse-iceoryx/iceoryx.git
+  GIT_TAG        v2.0.2
+  SOURCE_SUBDIR  iceoryx_meta
+)
+
+FetchContent_MakeAvailable(iceoryx)
+
+# This is needed to make sure that when building the tests, catch2's headers
+# are treated as system headers, as otherwise clang-tidy will run on them. This
+# is different from the above because clang-tidy will run on the headers which
+# is included from the tests, where as the above is for compiling catch2.
+#
+# After cmake 3.25, this shouldn't be needed anymore: https://gitlab.kitware.com/cmake/cmake/-/issues/18040
+get_target_property(ICEORYX_POSH_INC iceoryx_posh INTERFACE_INCLUDE_DIRECTORIES)
+set_target_properties(iceoryx_posh PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${ICEORYX_POSH_INC}")
+get_target_property(ICEORYX_HOOFS_INC iceoryx_hoofs INTERFACE_INCLUDE_DIRECTORIES)
+set_target_properties(iceoryx_hoofs PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${ICEORYX_HOOFS_INC}")
+
+add_executable(rt_iceoryx_example
+  src/main.cc
+)
+
+target_include_directories(rt_iceoryx_example
+  PRIVATE
+  include
+)
+
+target_link_libraries(rt_iceoryx_example
+  PRIVATE
+  cactus_rt
+  iceoryx_hoofs
+  iceoryx_posh
+  iceoryx_posh::iceoryx_posh_roudi
+)
+
+if (ENABLE_CLANG_TIDY)
+  set_target_properties(rt_iceoryx_example PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY_PATH})
+endif()
+
+install(
+  TARGETS rt_iceoryx_example
+  DESTINATION bin
+)

--- a/examples/iceoryx_example/CMakeLists.txt
+++ b/examples/iceoryx_example/CMakeLists.txt
@@ -24,6 +24,8 @@ set_target_properties(iceoryx_hoofs PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTOR
 
 add_executable(rt_iceoryx_example
   src/main.cc
+  src/publisher.cc
+  src/subscriber.cc
 )
 
 target_include_directories(rt_iceoryx_example

--- a/examples/iceoryx_example/include/data.h
+++ b/examples/iceoryx_example/include/data.h
@@ -1,0 +1,11 @@
+#ifndef CACTUS_RT_EXAMPLES_ICEORYX_EXAMPLE_DATA_H_
+#define CACTUS_RT_EXAMPLES_ICEORYX_EXAMPLE_DATA_H_
+
+#include <cstdint>
+
+struct Data {
+  int64_t time;
+  int64_t last_publish_time_taken;
+};
+
+#endif

--- a/examples/iceoryx_example/include/publisher.h
+++ b/examples/iceoryx_example/include/publisher.h
@@ -1,0 +1,23 @@
+#ifndef CACTUS_RT_EXAMPLES_ICEORYX_EXAMPLE_PUBLISHER_H_
+#define CACTUS_RT_EXAMPLES_ICEORYX_EXAMPLE_PUBLISHER_H_
+
+#include <cactus_rt/rt.h>
+
+#include <iceoryx_posh/popo/publisher.hpp>
+#include <memory>
+
+#include "data.h"
+
+class Publisher : public cactus_rt::CyclicThread<cactus_rt::schedulers::Fifo> {
+  int64_t                                     last_publish_time_taken_ = 0;
+  std::unique_ptr<iox::popo::Publisher<Data>> iceoryx_publisher_;
+
+ public:
+  Publisher();
+  void SetupIceoryx();
+
+ protected:
+  bool Loop(int64_t now) noexcept final;
+};
+
+#endif

--- a/examples/iceoryx_example/include/subscriber.h
+++ b/examples/iceoryx_example/include/subscriber.h
@@ -1,0 +1,25 @@
+#ifndef CACTUS_RT_EXAMPLES_ICEORYX_EXAMPLE_SUBSCRIBER_H_
+#define CACTUS_RT_EXAMPLES_ICEORYX_EXAMPLE_SUBSCRIBER_H_
+
+#include <cactus_rt/rt.h>
+
+#include <fstream>
+#include <iceoryx_posh/popo/subscriber.hpp>
+#include <memory>
+#include <vector>
+
+#include "data.h"
+
+class Subscriber : public cactus_rt::Thread<cactus_rt::schedulers::Other> {
+  std::unique_ptr<iox::popo::Subscriber<Data>> iceoryx_subscriber_;
+  std::vector<Data>                            data_buffer_;
+
+  std::ofstream data_file_;
+
+ public:
+  Subscriber();
+  void SetupIceoryx();
+  void Run() final;
+};
+
+#endif

--- a/examples/iceoryx_example/src/main.cc
+++ b/examples/iceoryx_example/src/main.cc
@@ -1,0 +1,3 @@
+int main() {
+  return 0;
+}

--- a/examples/iceoryx_example/src/main.cc
+++ b/examples/iceoryx_example/src/main.cc
@@ -1,3 +1,63 @@
+#include <cactus_rt/rt.h>
+#include <spdlog/spdlog.h>
+
+#include <iceoryx_posh/internal/roudi/roudi.hpp>
+#include <iceoryx_posh/roudi/iceoryx_roudi_components.hpp>
+#include <iceoryx_posh/runtime/posh_runtime_single_process.hpp>
+
+#include "publisher.h"
+#include "subscriber.h"
+
+class IceoryxExampleApp : public cactus_rt::App {
+  std::unique_ptr<iox::roudi::IceOryxRouDiComponents>     iceoryx_roudi_components_;
+  std::unique_ptr<iox::roudi::RouDi>                      iceoryx_roudi_;
+  std::unique_ptr<iox::runtime::PoshRuntimeSingleProcess> iceoryx_runtime_;
+
+  Publisher  publisher_;
+  Subscriber subscriber_;
+
+ public:
+  IceoryxExampleApp() {
+    // TODO: when iceoryx is included in the base framework, the thread
+    // constructors can setup iceroyx publishers directly because the
+    // constructor for cactus_rt::App would be the first thing that gets called
+    // as it is the base class for this class. I.e. the SetupIceroyx can be
+    // removed.
+    SetupIceoryxRuntimeInSingleProcessMode();
+
+    publisher_.SetupIceoryx();
+    subscriber_.SetupIceoryx();
+
+    RegisterThread(subscriber_);
+    RegisterThread(publisher_);
+  }
+
+ private:
+  void SetupIceoryxRuntimeInSingleProcessMode() {
+    iox::RouDiConfig_t default_config = iox::RouDiConfig_t().setDefaults();
+    iceoryx_roudi_components_ = std::make_unique<iox::roudi::IceOryxRouDiComponents>(default_config);
+
+    // The last bool parameter in RoudiStartupParameters states that RouDi does
+    // not terminate all registered processes when RouDi goes out of scope. If
+    // we would set it to true, our application would self terminate in the
+    // destructor of roudi
+    //
+    // TODO: understand what monitoring mode is
+    // TODO: what is the difference between IceoryxRoudiComponents and Roudi?
+    iceoryx_roudi_ = std::make_unique<iox::roudi::RouDi>(
+      iceoryx_roudi_components_->rouDiMemoryManager,
+      iceoryx_roudi_components_->portManager,
+      iox::roudi::RouDi::RoudiStartupParameters{iox::roudi::MonitoringMode::OFF, false});
+
+    iceoryx_runtime_ = std::make_unique<iox::runtime::PoshRuntimeSingleProcess>("rt_iceoryx_example");
+  }
+};
+
 int main() {
+  spdlog::set_level(spdlog::level::debug);
+
+  IceoryxExampleApp app;
+  app.Start();
+  app.Join();
   return 0;
 }

--- a/examples/iceoryx_example/src/publisher.cc
+++ b/examples/iceoryx_example/src/publisher.cc
@@ -1,0 +1,27 @@
+#include "publisher.h"
+
+Publisher::Publisher() : cactus_rt::CyclicThread<cactus_rt::schedulers::Fifo>("Publisher", 1'000'000, cactus_rt::schedulers::Fifo::Config{80}) {
+}
+
+void Publisher::SetupIceoryx() {
+  iox::popo::PublisherOptions publisherOptions;
+  publisherOptions.historyCapacity = 10U;
+  iceoryx_publisher_ = std::make_unique<iox::popo::Publisher<Data>>(
+    iox::capro::ServiceDescription{"Single", "Process", "Demo"},  // TODO: need to rename the service
+    publisherOptions);
+}
+
+bool Publisher::Loop(int64_t now) noexcept {
+  auto start = cactus_rt::NowNs();
+  // TODO: fully understand the future system.
+  // TODO: is lambdas real-time safe?
+  iceoryx_publisher_->loan().and_then([&](auto& sample) {
+    sample->time = now;
+    sample->last_publish_time_taken = last_publish_time_taken_;
+    sample.publish();
+  });
+
+  auto end = cactus_rt::NowNs();
+  last_publish_time_taken_ = end - start;
+  return false;
+}

--- a/examples/iceoryx_example/src/subscriber.cc
+++ b/examples/iceoryx_example/src/subscriber.cc
@@ -1,0 +1,59 @@
+#include "subscriber.h"
+
+#include <spdlog/spdlog.h>
+
+Subscriber::Subscriber() : cactus_rt::Thread<cactus_rt::schedulers::Other>("Subscriber") {
+}
+
+void Subscriber::SetupIceoryx() {
+  iox::popo::SubscriberOptions options;
+  options.queueCapacity = 10U;
+  options.historyRequest = 5U;
+  iceoryx_subscriber_ = std::make_unique<iox::popo::Subscriber<Data>>(
+    iox::capro::ServiceDescription{"Single", "Process", "Demo"},
+    options);
+
+  data_buffer_.reserve(8000);  // big enough...
+
+  data_file_.open("data.csv");
+  if (!data_file_.is_open()) {
+    throw std::runtime_error{"failed to open data file"};
+  }
+}
+
+void Subscriber::Run() {
+  while (!this->StopRequested()) {
+    if (iceoryx_subscriber_->getSubscriptionState() != iox::SubscribeState::SUBSCRIBED) {
+      // TODO: busy way is probably not that great?
+      continue;
+    }
+
+    bool has_more_samples = true;
+    while (has_more_samples) {
+      iceoryx_subscriber_->take()
+        .and_then([&](auto& sample) {
+          data_buffer_.emplace_back(*sample);
+        })
+        .or_else([&](auto& result) {
+          has_more_samples = false;
+          if (result != iox::popo::ChunkReceiveResult::NO_CHUNK_AVAILABLE) {
+            // Errors other than an empty queue! Needs handling
+            // TOOD: figure out what to do when no chunks are available
+          }
+        });
+    }
+
+    if (data_buffer_.size() >= 1000) {
+      size_t n = 0;
+      for (const auto& data : data_buffer_) {
+        data_file_ << data.time << ", " << data.last_publish_time_taken << "\n";
+        ++n;
+      }
+
+      SPDLOG_DEBUG("wrote {} entries to file", n);
+
+      // don't think this is fast. Ideally we just start the buffer from beginning without necessarily zeroing out the data.
+      data_buffer_.clear();
+    }
+  }
+}

--- a/examples/lttng_ust_example/CMakeLists.txt
+++ b/examples/lttng_ust_example/CMakeLists.txt
@@ -17,7 +17,7 @@ target_link_libraries(rt_lttng_ust_example
 )
 
 if (ENABLE_CLANG_TIDY)
-  set_target_properties(rt_lttng_ust_example PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY})
+  set_target_properties(rt_lttng_ust_example PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY_PATH})
 endif()
 
 install(

--- a/examples/message_passing_example/CMakeLists.txt
+++ b/examples/message_passing_example/CMakeLists.txt
@@ -18,7 +18,7 @@ target_link_libraries(rt_message_passing_example
 )
 
 if (ENABLE_CLANG_TIDY)
-  set_target_properties(rt_message_passing_example PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY})
+  set_target_properties(rt_message_passing_example PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY_PATH})
 endif()
 
 install(

--- a/examples/mutex_example/CMakeLists.txt
+++ b/examples/mutex_example/CMakeLists.txt
@@ -13,7 +13,7 @@ target_link_libraries(rt_mutex_example
 )
 
 if (ENABLE_CLANG_TIDY)
-  set_target_properties(rt_mutex_example PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY})
+  set_target_properties(rt_mutex_example PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY_PATH})
 endif()
 
 install(

--- a/examples/simple_deadline_example/CMakeLists.txt
+++ b/examples/simple_deadline_example/CMakeLists.txt
@@ -8,7 +8,7 @@ target_link_libraries(rt_simple_deadline_example
 )
 
 if (ENABLE_CLANG_TIDY)
-  set_target_properties(rt_simple_deadline_example PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY})
+  set_target_properties(rt_simple_deadline_example PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY_PATH})
 endif()
 
 install(

--- a/examples/simple_example/CMakeLists.txt
+++ b/examples/simple_example/CMakeLists.txt
@@ -8,7 +8,7 @@ target_link_libraries(rt_simple_example
 )
 
 if (ENABLE_CLANG_TIDY)
-  set_target_properties(rt_simple_example PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY})
+  set_target_properties(rt_simple_example PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY_PATH})
 endif()
 
 install(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,6 +35,10 @@ target_link_libraries(cactus_rt_tests
   Catch2::Catch2WithMain
 )
 
+if (ENABLE_CLANG_TIDY)
+  set_target_properties(cactus_rt_tests PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY_PATH})
+endif()
+
 list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/extras)
 include(CTest)
 include(Catch)


### PR DESCRIPTION
Iceoryx is an interesting library that allows one to easily communicate between processes and threads with zero latency using shared memory approach. This example creates a RT application with two threads that communicate with single-process iceoryx communication (as opposed to multi-process, shared-memory-based communication).

If this is indeed a promising approach, perhaps it is a good idea to incorporate iceoryx directly into the cactus-rt framework.

### Some other changes

Also had to rename the cmake variable `CLANG_TIDY` to `CLANG_TIDY_PATH` because iceoryx expects a variable called `CLANG_TIDY` to enable its own clang-tidy process. If we didn't rename this variable, it would mean that `ENABLE_CLANG_TIDY=ON` would also enable clang-tidy for iceoryx, which we don't want to do.

Also added `.vscode/c_cpp_properties.json` to make development in vscode a bit easier.