### PR TITLE
Explicitly instantiate CyclicThread<SchedulerT>

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(spdlog REQUIRED)
 add_library(cactus_rt
   STATIC
   src/app.cc
+  src/cyclic_thread.cc
   src/latency_tracker.cc
   src/signal_handler.cc
 )

--- a/include/cactus_rt/schedulers/deadline.h
+++ b/include/cactus_rt/schedulers/deadline.h
@@ -7,7 +7,8 @@
 #include <cerrno>
 #include <ctime>
 
-#include "cactus_rt/linux/sched_ext.h"
+#include "../cyclic_thread.h"
+#include "../linux/sched_ext.h"
 
 constexpr size_t kDefaultStackSize = 8 * 1024 * 1024;  // 8MB
 

--- a/include/cactus_rt/schedulers/fifo.h
+++ b/include/cactus_rt/schedulers/fifo.h
@@ -7,7 +7,7 @@
 #include <cerrno>
 #include <ctime>
 
-#include "cactus_rt/linux/sched_ext.h"
+#include "../linux/sched_ext.h"
 
 namespace cactus_rt::schedulers {
 class Fifo {

--- a/include/cactus_rt/schedulers/other.h
+++ b/include/cactus_rt/schedulers/other.h
@@ -7,7 +7,7 @@
 #include <cerrno>
 #include <ctime>
 
-#include "cactus_rt/linux/sched_ext.h"
+#include "../linux/sched_ext.h"
 
 namespace cactus_rt::schedulers {
 class Other {

--- a/src/cyclic_thread.cc
+++ b/src/cyclic_thread.cc
@@ -1,0 +1,63 @@
+#include "cactus_rt/cyclic_thread.h"
+
+#include <spdlog/spdlog.h>
+
+#include "cactus_rt/schedulers/deadline.h"
+#include "cactus_rt/schedulers/fifo.h"
+#include "cactus_rt/schedulers/other.h"
+
+namespace cactus_rt {
+
+template <typename SchedulerT>
+void CyclicThread<SchedulerT>::Run() noexcept {
+  clock_gettime(CLOCK_MONOTONIC, &next_wakeup_time_);
+  int64_t loop_start, loop_end, should_have_woken_up_at;
+
+  int64_t wakeup_latency, loop_latency, busy_wait_latency;
+
+  while (!this->StopRequested()) {
+    should_have_woken_up_at = next_wakeup_time_.tv_sec * 1'000'000'000 + next_wakeup_time_.tv_nsec;
+    loop_start = NowNs();
+
+    wakeup_latency = loop_start - should_have_woken_up_at;
+
+    TraceLoopStart(wakeup_latency);
+
+    if (Loop(loop_start - Thread<SchedulerT>::StartMonotonicTimeNs())) {
+      break;
+    }
+
+    loop_end = NowNs();
+    loop_latency = static_cast<double>(loop_end - loop_start);
+
+    TraceLoopEnd(loop_latency);
+
+    wakeup_latency_tracker_.RecordValue(wakeup_latency);
+    loop_latency_tracker_.RecordValue(loop_latency);
+
+    next_wakeup_time_ = AddTimespecByNs(next_wakeup_time_, period_ns_);
+    busy_wait_latency = SchedulerT::Sleep(next_wakeup_time_);
+
+    busy_wait_latency_tracker_.RecordValue(busy_wait_latency);
+  }
+}
+
+template <typename SchedulerT>
+void CyclicThread<SchedulerT>::AfterRun() {
+  SPDLOG_DEBUG("wakeup_latency:");
+  wakeup_latency_tracker_.DumpToLogger();
+
+  SPDLOG_DEBUG("loop_latency:");
+  loop_latency_tracker_.DumpToLogger();
+
+  SPDLOG_DEBUG("busy_wait_latency:");
+  busy_wait_latency_tracker_.DumpToLogger();
+};
+
+// Need explicit definition because the template class of CyclicThread is not
+// defined inline. This is needed because Perfetto definitions can't be
+// included multiple times without a lot of problems (prior to v31).
+template class CyclicThread<schedulers::Deadline>;
+template class CyclicThread<schedulers::Fifo>;
+template class CyclicThread<schedulers::Other>;
+}  // namespace cactus_rt


### PR DESCRIPTION
This is needed to move the code definition out of the header file. Later, when we implement built-in tracing via Perfetto, we can't include the Perfetto header into the Cactus RT headers. This is because defining Perfetto tracing categories requires a pile of macros that won't play very well when included and called multiple times in the same translation unit (although this is resolved with [this commit][1], which is not released at this time). Since the cyclic thread code need to include the Perfetto headers, and user code depends on cyclic_thread.h, the only way to sanely include headers is to move the cyclic thread code into its own translation unit, which then requires explicit instantiation of the different threads.

[1]: https://github.com/google/perfetto/commit/6020a92b81bb64bf66b99cf85d37eab2f8ded9fb