### PR TITLE
Perfetto built-in to cactus-rt

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -16,6 +16,7 @@ cert-*,
 -modernize-use-nodiscard,
 -modernize-use-trailing-return-type,
 -readability-convert-member-functions-to-static,
+-readability-function-cognitive-complexity,
 -readability-identifier-length,
 -readability-isolate-declaration,
 -readability-magic-numbers'

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build/
 data/
 .ipynb_checkpoints
 *.svg
+*.perfetto-trace
 
 .vscode/settings.json
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,23 @@ option(ENABLE_CLANG_TIDY "Run clang-tidy" OFF)
 option(ENABLE_EXAMPLES "Build example programs" ON)
 option(BUILD_DOCS "Build documentations" OFF)
 
+# This is technically not right because build type could be a build-type
+# variable due to multi-configuration generator. That said, ENABLE_TRACING is a
+# configuration time variable so this is the right thing to do. It just means we
+# can't easily build with ninja and visual studio, which is probably fine.
+#
+# See: https://mesos.apache.org/documentation/latest/cmake-examples/#building-debug-or-release-configurations
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+  set(ENABLE_TRACING_DEFAULT ON)
+else()
+  set(ENABLE_TRACING_DEFAULT OFF)
+endif()
+
+option(ENABLE_TRACING
+  "Build with Perfetto-based tracing enabled"
+  ${ENABLE_TRACING_DEFAULT}
+)
+
 # https://stackoverflow.com/questions/5395309/how-do-i-force-cmake-to-include-pthread-option-during-compilation
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)
@@ -61,6 +78,43 @@ target_compile_definitions(cactus_rt
   PUBLIC
   "$<IF:$<CONFIG:Debug>,SPDLOG_ACTIVE_LEVEL=1,>"
 )
+
+if (ENABLE_TRACING)
+  include(FetchContent)
+
+  message(WARNING "Tracing with Perfetto is enabled as ENABLE_TRACING=${ENABLE_TRACING}. This is enabled by default in debug builds. However, this is not a real-time-safe configuration for production use and is for debug only!!! Change to a release build to ensure this is not turned on.")
+
+  FetchContent_Declare(
+    perfetto
+    GIT_REPOSITORY https://android.googlesource.com/platform/external/perfetto
+    GIT_TAG        v31.0 # Once v32 is released, change this v32.
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND     ""
+  )
+
+  FetchContent_MakeAvailable(perfetto)
+
+  add_library(perfetto_sdk
+    STATIC
+    ${perfetto_SOURCE_DIR}/sdk/perfetto.cc
+  )
+
+  # TODO: should these be public?
+  target_include_directories(cactus_rt
+    SYSTEM PUBLIC
+    ${perfetto_SOURCE_DIR}/sdk
+  )
+
+  target_link_libraries(cactus_rt
+    PUBLIC
+    perfetto_sdk
+  )
+
+  target_compile_definitions(cactus_rt
+    PUBLIC
+    ENABLE_TRACING=1
+  )
+endif()
 
 # Only enable clang-tidy and ctest if this is the main project and not being included further.
 if(${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,7 @@ if(${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME})
     add_subdirectory(examples/mutex_example)
     add_subdirectory(examples/lttng_ust_example)
     add_subdirectory(examples/simple_deadline_example)
+    add_subdirectory(examples/tracing_example)
   endif()
 
   if (BUILD_DOCS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(cactus_rt
   src/app.cc
   src/latency_tracker.cc
   src/signal_handler.cc
+  src/support/tracing.cc
 )
 
 target_compile_features(cactus_rt

--- a/examples/simple_example/main.cc
+++ b/examples/simple_example/main.cc
@@ -23,11 +23,6 @@ class RTApp : public cactus_rt::App {
   RTApp(std::vector<size_t> cpu_affinity) : thread_(cpu_affinity) {
     RegisterThread(thread_);
   }
-
-  void Stop() {
-    thread_.RequestStop();
-    thread_.Join();
-  }
 };
 
 int main() {
@@ -39,6 +34,7 @@ int main() {
   SPDLOG_INFO("Testing latency for {}s", time);
   app.Start();
   sleep(time);
-  app.Stop();
+  app.RequestStop();
+  app.Join();
   return 0;
 }

--- a/examples/tracing_example/CMakeLists.txt
+++ b/examples/tracing_example/CMakeLists.txt
@@ -1,0 +1,17 @@
+add_executable(rt_tracing_example
+  main.cc
+)
+
+target_link_libraries(rt_tracing_example
+  PRIVATE
+  cactus_rt
+)
+
+if (ENABLE_CLANG_TIDY)
+  set_target_properties(rt_tracing_example PROPERTIES CXX_CLANG_TIDY ${CLANG_TIDY})
+endif()
+
+install(
+  TARGETS rt_tracing_example
+  DESTINATION bin
+)

--- a/examples/tracing_example/main.cc
+++ b/examples/tracing_example/main.cc
@@ -1,0 +1,77 @@
+#include <cactus_rt/rt.h>
+#include <spdlog/spdlog.h>
+#include <unistd.h>
+
+class MyThread : public cactus_rt::CyclicThread<cactus_rt::schedulers::Fifo> {
+  int n_ = 0;
+
+ public:
+  MyThread(std::vector<size_t> cpu_affinity)
+      : cactus_rt::CyclicThread<cactus_rt::schedulers::Fifo>("MyThread", 1'000'000, /* Period */
+                                                             cactus_rt::schedulers::Fifo::Config{80 /* Priority */},
+                                                             cpu_affinity) {}
+
+  int Result() const {
+    return n_;
+  }
+
+ protected:
+  bool Loop(int64_t /*now*/) noexcept final {
+    {
+      TRACE_EVENT(cactus_rt::kTracingCategoryRealTime, "MyThread::Region1");
+      n_ += NumFactors(30000);
+    }
+
+    {
+      TRACE_EVENT(cactus_rt::kTracingCategoryRealTime, "MyThread::Region2");
+      n_ += NumFactors(150000);
+    }
+
+    {
+      TRACE_EVENT(cactus_rt::kTracingCategoryRealTime, "MyThread::Region3");
+      n_ += NumFactors(90000);
+    }
+
+    return false;
+  }
+
+ private:
+  int NumFactors(int n) {
+    int c = 0;
+    for (int i = 1; i < n; i++) {
+      if (n % i == 0) {
+        c++;
+      }
+    }
+
+    return c;
+  }
+};
+
+class RTApp : public cactus_rt::App {
+  MyThread thread_;
+
+ public:
+  RTApp(std::vector<size_t> cpu_affinity) : thread_(cpu_affinity) {
+    RegisterThread(thread_);
+  }
+
+  int Result() const {
+    return thread_.Result();
+  }
+};
+
+int main() {
+  spdlog::set_level(spdlog::level::debug);
+
+  RTApp app(std::vector<size_t>{2});
+
+  constexpr unsigned int time = 5;
+  SPDLOG_INFO("Testing latency for {}s", time);
+  app.Start();
+  sleep(time);
+  app.RequestStop();
+  app.Join();
+  SPDLOG_INFO("result: {}", app.Result());
+  return 0;
+}

--- a/include/cactus_rt/app.h
+++ b/include/cactus_rt/app.h
@@ -6,6 +6,7 @@
 #include <map>
 #include <memory>
 
+#include "support/tracing.h"
 #include "thread.h"
 
 namespace cactus_rt {
@@ -18,6 +19,8 @@ class App {
   // Non-owning references to threads just to help with starting and joining the thread.
   std::vector<BaseThread*> threads_;
 
+  std::unique_ptr<Tracer> tracer_;
+
  public:
   /**
    * @brief Creates an instance of the RT app. The app should always be created
@@ -25,7 +28,7 @@ class App {
    *
    * @param heap_size The heap size to reserve in bytes. Defaults to 0 which means no heap memory will be reserved.
    */
-  explicit App(size_t heap_size = 0) : heap_size_(heap_size) {}
+  explicit App(size_t heap_size = 0);
   virtual ~App() = default;
 
   // Copy constructors
@@ -51,6 +54,13 @@ class App {
    * start all the threads in registration order.
    */
   virtual void Start();
+
+  /**
+   * @brief Requests all the threads to stop.
+   *
+   * Call App::Join to ensure that all threads are stopped before quitting.
+   */
+  virtual void RequestStop();
 
   /**
    * @brief Joins all the threads in registration order.
@@ -82,6 +92,22 @@ class App {
    * Reserve the heap based on the heap_size_.
    */
   void ReserveHeap() const;
+
+  /**
+   * @brief Get the Tracer Parameters object for this app. By default, this is
+   * constructed from environment variables as follows:
+   *
+   * - TODO: list environment variables
+   *
+   * @return TracerParameters A constructed TraceParameter object with all values.
+   */
+  virtual TracerParameters GetTracerParameters() const {
+    return TracerParameters::FromEnv();
+  };
+
+  void SetupTracer();
+  void StartTracing();
+  void StopTracing();
 };
 }  // namespace cactus_rt
 

--- a/include/cactus_rt/rt.h
+++ b/include/cactus_rt/rt.h
@@ -6,5 +6,6 @@
 #include "schedulers/fifo.h"
 #include "schedulers/other.h"
 #include "signal_handler.h"
+#include "support/tracing.h"
 #include "thread.h"
 #include "utils.h"

--- a/include/cactus_rt/support/tracing.h
+++ b/include/cactus_rt/support/tracing.h
@@ -1,0 +1,88 @@
+#ifndef CACTUS_RT_SUPPORT_TRACING_H_
+#define CACTUS_RT_SUPPORT_TRACING_H_
+#include <cstdint>
+
+namespace cactus_rt {
+
+class Tracer {
+ public:
+  Tracer() = default;
+  virtual ~Tracer() = default;
+
+  Tracer(const Tracer&) = delete;
+  Tracer& operator=(const Tracer&) = delete;
+
+  Tracer(Tracer&&) = delete;
+  Tracer& operator=(Tracer&&) = delete;
+
+  virtual void Start() = 0;
+  virtual void Stop() = 0;
+};
+
+struct TracerParameters {
+  uint32_t bufsize = 16 * 1024;
+  uint32_t file_write_period_ms = 2000;
+  uint32_t flush_period_ms = 2000;
+
+  static TracerParameters FromEnv() {
+    TracerParameters params;
+
+    // TODO: FIX ME BEFORE MERGE: read the parameters from the environment
+
+    return params;
+  }
+};
+
+constexpr const char* kTracingCategoryInternal = "cactus_rt";
+constexpr const char* kTracingCategoryRealTime = "rt";
+constexpr const char* kTracingCategoryNonRealTime = "nonrt";
+constexpr const char* kTracingCategoryCustom1 = "custom1";
+constexpr const char* kTracingCategoryCustom2 = "custom2";
+constexpr const char* kTracingCategoryCustom3 = "custom3";
+}  // namespace cactus_rt
+
+#ifdef ENABLE_TRACING
+#include <perfetto.h>
+
+#include <memory>
+
+// TODO: switch to PERFETTO_DEFINE_CATEOGIRES_IN_NAMESPACE for Perfetto v32
+// NOLINTBEGIN
+PERFETTO_DEFINE_CATEGORIES(
+  perfetto::Category(cactus_rt::kTracingCategoryInternal).SetDescription("Events from the cactus-rt framework internals"),
+  perfetto::Category(cactus_rt::kTracingCategoryRealTime).SetDescription("Custom application events from real-time threads"),
+  perfetto::Category(cactus_rt::kTracingCategoryNonRealTime).SetDescription("Custom application events from non-real-time threads"),
+  perfetto::Category(cactus_rt::kTracingCategoryCustom1).SetDescription("Arbitrary custom application events 1"),
+  perfetto::Category(cactus_rt::kTracingCategoryCustom2).SetDescription("Arbitrary custom application events 2"),
+  perfetto::Category(cactus_rt::kTracingCategoryCustom3).SetDescription("Arbitrary custom application events 3"));
+// NOLINTEND
+
+namespace cactus_rt {
+class InProcessTracer : public Tracer {
+  const char*                               filename_;
+  TracerParameters                          params_;
+  std::unique_ptr<perfetto::TracingSession> tracing_session_;
+  perfetto::TraceConfig                     trace_config_;
+  int                                       log_file_fd_;
+
+ public:
+  InProcessTracer(const char*      filename,
+                  TracerParameters params);
+  ~InProcessTracer() override;
+  void Start() override;
+  void Stop() override;
+};
+}  // namespace cactus_rt
+
+#else
+
+// Turn perfetto trace into no-ops
+// TODO: there may be more macros to overwrite.
+#define TRACE_EVENT(...)
+#define TRACE_EVENT_BEGIN(...)
+#define TRACE_EVENT_END(...)
+#define TRACE_COUNTER(...)
+
+#endif
+
+#endif

--- a/include/cactus_rt/thread.h
+++ b/include/cactus_rt/thread.h
@@ -22,7 +22,7 @@ class BaseThread {
   std::atomic_bool stop_requested_ = false;
 
  public:
-  virtual const std::string& Name() = 0;
+  virtual const std::string& Name() const = 0;
   virtual void               Start(int64_t start_monotonic_time_ns, int64_t start_wall_time_ns) = 0;
   virtual int                Join() = 0;
 
@@ -97,7 +97,7 @@ class Thread : public BaseThread {
         // In case stack_size is 0...
         stack_size_(static_cast<size_t>(PTHREAD_STACK_MIN) + stack_size){};
 
-  const std::string& Name() override {
+  const std::string& Name() const override {
     return name_;
   }
 

--- a/include/cactus_rt/utils.h
+++ b/include/cactus_rt/utils.h
@@ -2,6 +2,7 @@
 #define CACTUS_RT_UTILS_H_
 
 #include <cstdint>
+#include <cstdlib>
 #include <ctime>
 
 namespace cactus_rt {
@@ -34,7 +35,7 @@ inline struct timespec AddTimespecByNs(struct timespec ts, int64_t ns) {
 }
 
 inline const char* GetEnv(const char* envname, const char* default_value = "") {
-  const char* value = std::getenv(envname);
+  const char* value = getenv(envname);
   if (value == nullptr) {
     value = default_value;
   }

--- a/include/cactus_rt/utils.h
+++ b/include/cactus_rt/utils.h
@@ -33,6 +33,15 @@ inline struct timespec AddTimespecByNs(struct timespec ts, int64_t ns) {
   return ts;
 }
 
+inline const char* GetEnv(const char* envname, const char* default_value = "") {
+  const char* value = std::getenv(envname);
+  if (value == nullptr) {
+    value = default_value;
+  }
+
+  return value;
+}
+
 }  // namespace cactus_rt
 
 #endif

--- a/src/app.cc
+++ b/src/app.cc
@@ -11,7 +11,6 @@
 namespace cactus_rt {
 
 App::App(size_t heap_size) : heap_size_(heap_size) {
-  SetupTracer();
 }
 
 void App::RegisterThread(BaseThread& thread) {
@@ -21,6 +20,7 @@ void App::RegisterThread(BaseThread& thread) {
 void App::Start() {
   SPDLOG_DEBUG("Starting application");
 
+  SetupTracer();
   StartTracing();
 
   LockMemory();

--- a/src/app.cc
+++ b/src/app.cc
@@ -9,12 +9,19 @@
 #include "cactus_rt/utils.h"
 
 namespace cactus_rt {
+
+App::App(size_t heap_size) : heap_size_(heap_size) {
+  SetupTracer();
+}
+
 void App::RegisterThread(BaseThread& thread) {
   threads_.push_back(&thread);
 }
 
 void App::Start() {
   SPDLOG_DEBUG("Starting application");
+
+  StartTracing();
 
   LockMemory();
   ReserveHeap();
@@ -34,10 +41,18 @@ void App::Start() {
   }
 }
 
+void App::RequestStop() {
+  for (auto* thread : threads_) {
+    thread->RequestStop();
+  }
+}
+
 void App::Join() {
   for (auto* thread : threads_) {
     thread->Join();
   }
+
+  StopTracing();
 }
 
 void App::ReserveHeap() const {
@@ -102,5 +117,25 @@ void App::LockMemory() const {
   if (ret == 0) {
     throw std::runtime_error{"mallopt M_TRIM_THRESHOLD failed"};
   }
+}
+
+void App::SetupTracer() {
+#ifdef ENABLE_TRACING
+  // TODO: refactor the filename into TracerParameters.
+  const char* filename = GetEnv("CACTUS_RT_TRACE_LOG_FILE", "run.perfetto-trace");
+  tracer_ = std::make_unique<InProcessTracer>(filename, GetTracerParameters());
+#endif
+}
+
+void App::StartTracing() {
+#ifdef ENABLE_TRACING
+  tracer_->Start();
+#endif
+}
+
+void App::StopTracing() {
+#ifdef ENABLE_TRACING
+  tracer_->Stop();
+#endif
 }
 }  // namespace cactus_rt

--- a/src/support/tracing.cc
+++ b/src/support/tracing.cc
@@ -1,0 +1,69 @@
+#include "cactus_rt/support/tracing.h"
+
+#include <fcntl.h>
+#include <spdlog/spdlog.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include <cstring>
+
+#ifdef ENABLE_TRACING
+
+// NOLINTBEGIN
+PERFETTO_TRACK_EVENT_STATIC_STORAGE();
+// NOLINTEND
+
+namespace cactus_rt {
+InProcessTracer::InProcessTracer(const char* filename, TracerParameters params) : filename_(filename), params_(params) {
+  perfetto::TracingInitArgs args;
+  args.backends = perfetto::kInProcessBackend;
+  // If I specify the system backend, the loop executes slower and also no trace data is recorded?
+  // TODO: figure out why. Specifically the slower loop doesn't seem good.
+  // args.backends |= perfetto::kSystemBackend;
+
+  perfetto::Tracing::Initialize(args);
+  perfetto::TrackEvent::Register();
+
+  log_file_fd_ = open(filename, O_RDWR | O_CREAT | O_TRUNC, 0644);
+  if (log_file_fd_ == -1) {
+    throw std::runtime_error{std::string("failed to open log file: ") + std::strerror(errno)};
+  }
+}
+
+InProcessTracer::~InProcessTracer() {
+  auto ret = close(log_file_fd_);
+  if (ret != 0) {
+    SPDLOG_ERROR("Failed to close tracing file: {}", std::strerror(errno));
+  }
+}
+
+void InProcessTracer::Start() {
+  trace_config_.add_buffers()->set_size_kb(params_.bufsize);
+  trace_config_.set_write_into_file(true);
+  trace_config_.set_file_write_period_ms(params_.file_write_period_ms);
+  trace_config_.set_flush_period_ms(params_.flush_period_ms);
+
+  auto* data_source_config = trace_config_.add_data_sources()->mutable_config();
+  data_source_config->set_name("track_event");
+
+  // By default, all non-debug categories are enabled.
+  perfetto::protos::gen::TrackEventConfig track_event_config;
+  track_event_config.add_enabled_categories("*");
+  data_source_config->set_track_event_config_raw(track_event_config.SerializeAsString());
+
+  // NewTrace must be called after tracing config? Otherwise there's a segfault
+  tracing_session_ = perfetto::Tracing::NewTrace();
+  tracing_session_->Setup(trace_config_, log_file_fd_);
+
+  tracing_session_->StartBlocking();
+  SPDLOG_WARN("Tracing has started via Perfetto and logging to {}.", filename_);
+  SPDLOG_WARN("While tracing overhead should be low, it should not be used in release builds at this time.");
+  SPDLOG_WARN("Tracing can be disabled by compiling cactus_rt with ENABLE_TRACING=OFF.");
+}
+
+void InProcessTracer::Stop() {
+  tracing_session_->StopBlocking();
+  SPDLOG_WARN("Tracing has stopped.");
+}
+}  // namespace cactus_rt
+#endif


### PR DESCRIPTION
Things to implement before PR is ready:

- [ ] Test ENABLE_TRACING=OFF
- [ ] Test perfetto daemon-based tracing?
- [ ] Dynamically enable/disable tracing to avoid very large trace files. Alternative, fixed duration (like 5 seconds) tracing (will have to integrate with signal handling in case of early termination).
- [ ] Trace parameter rework + environment variables

Example trace from `tracing_example`:

![Screenshot from 2023-01-23 10-52-12](https://user-images.githubusercontent.com/338100/214085514-553ee093-757f-45eb-9381-8054c8861ff8.png)
