### PR TITLE
Do not reserve memory by default

### DIFF
--- a/include/cactus_rt/app.h
+++ b/include/cactus_rt/app.h
@@ -23,9 +23,9 @@ class App {
    * @brief Creates an instance of the RT app. The app should always be created
    * before the threads as some global setup that can take place.
    *
-   * @param heap_size The heap size to reserve in bytes. Defaults to 512MB.
+   * @param heap_size The heap size to reserve in bytes. Defaults to 0 which means no heap memory will be reserved.
    */
-  explicit App(size_t heap_size = 512 * 1024 * 1024) : heap_size_(heap_size) {}
+  explicit App(size_t heap_size = 0) : heap_size_(heap_size) {}
   virtual ~App() = default;
 
   // Copy constructors

--- a/src/app.cc
+++ b/src/app.cc
@@ -46,6 +46,8 @@ void App::ReserveHeap() const {
     return;
   }
 
+  SPDLOG_INFO("reserving {} bytes of heap memory", heap_size_);
+
   void* buf = malloc(heap_size_);
   if (buf == nullptr) {
     SPDLOG_ERROR("cannot malloc: {}", std::strerror(errno));


### PR DESCRIPTION
Fixes #4. While reserving heap memory by default can be helpful, reserving 512MB of memory is probably quite excessive, as some devices may not have that much RAM to spare (think Raspberry Pis). Avoiding default heap allocation is likely a good idea.