### PR TITLE
Building in debug or release mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,6 @@ option(ENABLE_CLANG_TIDY "Run clang-tidy" OFF)
 option(ENABLE_EXAMPLES "Build example programs" ON)
 option(BUILD_DOCS "Build documentations" OFF)
 
-add_definitions(-DSPDLOG_ACTIVE_LEVEL=1) # debug level
-
 # https://stackoverflow.com/questions/5395309/how-do-i-force-cmake-to-include-pthread-option-during-compilation
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)
@@ -57,7 +55,11 @@ target_compile_options(cactus_rt
   -Wnull-dereference
   -Wuseless-cast
   -Wdouble-promotion
-  -g # TODO: release vs debug
+)
+
+target_compile_definitions(cactus_rt
+  PUBLIC
+  "$<IF:$<CONFIG:Debug>,SPDLOG_ACTIVE_LEVEL=1,>"
 )
 
 # Only enable clang-tidy and ctest if this is the main project and not being included further.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+.PHONY: release debug clean clean-all
+
+ENABLE_CLANG_TIDY ?= OFF
+ENABLE_EXAMPLES ?= ON
+BUILD_DOCS ?= OFF
+BUILD_TESTING ?= OFF
+CMAKE_FLAGS := -DENABLE_CLANG_TIDY=$(ENABLE_CLANG_TIDY) -DENABLE_EXAMPLES=$(ENABLE_EXAMPLES) -DBUILD_DOCS=$(BUILD_DOCS) -DBUILD_TESTING=$(BUILD_TESTING)
+
+debug:
+	cmake -Bbuild/$@ -DCMAKE_BUILD_TYPE=Debug $(CMAKE_FLAGS)
+	cmake --build build/$@ -j $$(nproc)
+
+release:
+	cmake -Bbuild/$@ -DCMAKE_BUILD_TYPE=RelWithDebInfo $(CMAKE_FLAGS)
+	cmake --build build/$@ -j $$(nproc)
+
+clean:
+	test ! -d build/debug || cmake --build build/debug --target clean
+	test ! -d build/release || cmake --build build/release --target clean
+
+clean-all:
+	rm build -rf

--- a/README.rst
+++ b/README.rst
@@ -97,24 +97,61 @@ Of course you also need a C++ compiler and cmake.
 Build
 -----
 
+To build in debug mode:
+
 .. code-block:: console
 
-   $ cmake -Bbuild
-   $ cmake --build build -j $(nproc)
+   $ make debug
+
+To run an example:
+
+.. code-block:: console
+
+   $ sudo build/debug/examples/simple_example/rt_simple_example
 
 To turn on ``clang-tidy``:
 
 .. code-block:: console
 
-   $ cmake -Bbuild -DENABLE_CLANG_TIDY=ON
-   $ cmake --build build -j $(nproc)
+   $ make debug ENABLE_CLANG_TIDY=ON
 
-To turn OFF building the examples (for embedding into other projects):
+For compiling in release mode:
 
 .. code-block:: console
 
-   $ cmake -Bbuild -DENABLE_EXAMPLES=OFF
-   $ cmake --build build -j $(nproc)
+   $ make release
+
+All flags remain valid for both ``make debug`` and ``make release``. Consult
+the ``Makefile`` for details on how it works as it is just a convenience
+wrapper on cmake. The example binaries will be located in the folder
+``build/release`` instead of ``build/debug``.
+
+To turn OFF building the examples:
+
+.. code-block:: console
+
+   $ make debug ENABLE_EXAMPLES=OFF
+
+To build into other projects, simply use ``FetchContent`` in your
+``CMakeLists.txt`` file:
+
+.. code-block:: cmake
+
+   include(FetchContent)
+   FetchContent_Declare(
+     cactus_rt
+     GIT_REPOSITORY https://github.com/cactusdynamics/cactus-rt.git
+     GIT_TAG        ...
+   )
+   FetchContent_MakeAvailable(cactus_rt)
+
+   # ...
+
+   target_link_libraries(myapp PRIVATE cactus_rt)
+
+Note that if you compile your app in debug mode, cactus-rt will be compiled in
+debug mode due to how ``FetchContent`` works. To get cactus-rt in release mode,
+compile your app in release mode.
 
 For testing like CI, you need docker installed and then you can use:
 


### PR DESCRIPTION
Changed cmake so the code can be built in release or debug mode. In debug mode, the SPDLOG level is set to DEBUG while in release mode it is unset (so defaults to INFO). This decision could be revisited later.