### PR TITLE
Thread rework

### DIFF
--- a/examples/logging_example/main.cc
+++ b/examples/logging_example/main.cc
@@ -32,16 +32,13 @@ class ExampleRTThread : public CyclicThread {
 };
 
 int main() {
-  cactus_rt::FifoThreadConfig fifo_config;
-  fifo_config.priority = 80;
+  cactus_rt::CyclicThreadConfig thread_config;
+  thread_config.name = "ExampleRTThread";
+  thread_config.period_ns = 1'000'000;
+  thread_config.cpu_affinity = std::vector<size_t>{2};
+  thread_config.SetFifoScheduler(80);
 
-  cactus_rt::CyclicThreadConfig config;
-  config.name = "ExampleRTThread";
-  config.period_ns = 1'000'000;
-  config.cpu_affinity = std::vector<size_t>{2};
-  config.scheduler_config = fifo_config;
-
-  auto thread = std::make_shared<ExampleRTThread>(config);
+  auto thread = std::make_shared<ExampleRTThread>(thread_config);
 
   // Create a cactus_rt app configuration
   cactus_rt::AppConfig app_config;

--- a/examples/logging_example/main.cc
+++ b/examples/logging_example/main.cc
@@ -14,8 +14,7 @@ class ExampleRTThread : public CyclicThread {
   int64_t loop_counter_ = 0;
 
  public:
-  ExampleRTThread(cactus_rt::CyclicThreadConfig config) : CyclicThread(config
-                                                          ) {}
+  ExampleRTThread(const char* name, cactus_rt::CyclicThreadConfig config) : CyclicThread(name, config) {}
 
   int64_t GetLoopCounter() const {
     return loop_counter_;
@@ -33,12 +32,11 @@ class ExampleRTThread : public CyclicThread {
 
 int main() {
   cactus_rt::CyclicThreadConfig thread_config;
-  thread_config.name = "ExampleRTThread";
   thread_config.period_ns = 1'000'000;
   thread_config.cpu_affinity = std::vector<size_t>{2};
   thread_config.SetFifoScheduler(80);
 
-  auto thread = std::make_shared<ExampleRTThread>(thread_config);
+  auto thread = std::make_shared<ExampleRTThread>("ExampleRTThread", thread_config);
 
   // Create a cactus_rt app configuration
   cactus_rt::AppConfig app_config;

--- a/examples/message_passing_example/data_logger_thread.cc
+++ b/examples/message_passing_example/data_logger_thread.cc
@@ -2,19 +2,11 @@
 
 #include <chrono>
 
-namespace {
-cactus_rt::ThreadConfig MakeDataLoggerThreadConfig() {
-  cactus_rt::ThreadConfig config;
-  config.name = "DataLogger";
-  return config;
-}
-}  // namespace
-
 DataLogger::DataLogger(
   const std::string& data_file_path,
   int64_t            period_ns,
   int64_t            write_data_interval_ns
-) : Thread(MakeDataLoggerThreadConfig()),
+) : Thread("DataLogger", cactus_rt::ThreadConfig()),
     period_ns_(period_ns),
     write_data_interval_ns_(write_data_interval_ns),
     queue_(kQueueCapacity),

--- a/examples/message_passing_example/rt_thread.h
+++ b/examples/message_passing_example/rt_thread.h
@@ -15,13 +15,11 @@ class RtThread : public CyclicThread {
   size_t                      iterations_ = 0;
 
   static cactus_rt::CyclicThreadConfig MakeRealTimeThreadConfig() {
-    cactus_rt::FifoThreadConfig fifo_config;
-    fifo_config.priority = 80;
-
     cactus_rt::CyclicThreadConfig config;
     config.name = "RtThread";
     config.period_ns = 1'000'000;
-    config.scheduler_config = fifo_config;
+    config.cpu_affinity = std::vector<size_t>{2};
+    config.SetFifoScheduler(80);
 
     return config;
   }

--- a/examples/message_passing_example/rt_thread.h
+++ b/examples/message_passing_example/rt_thread.h
@@ -16,7 +16,6 @@ class RtThread : public CyclicThread {
 
   static cactus_rt::CyclicThreadConfig MakeRealTimeThreadConfig() {
     cactus_rt::CyclicThreadConfig config;
-    config.name = "RtThread";
     config.period_ns = 1'000'000;
     config.cpu_affinity = std::vector<size_t>{2};
     config.SetFifoScheduler(80);
@@ -26,7 +25,7 @@ class RtThread : public CyclicThread {
 
  public:
   RtThread(std::shared_ptr<DataLogger> data_logger, size_t max_iterations = 30000)
-      : CyclicThread(MakeRealTimeThreadConfig()),
+      : CyclicThread("RtThread", MakeRealTimeThreadConfig()),
         data_logger_(data_logger),
         max_iterations_(max_iterations) {
   }

--- a/examples/mutex_example/main.cc
+++ b/examples/mutex_example/main.cc
@@ -73,8 +73,6 @@ void ThreadedDemo() {
   rt_thread_config.period_ns = 1'000'000;
   rt_thread_config.SetFifoScheduler(80 /* priority */);
 
-  const cactus_rt::OtherThreadConfig other_config;
-
   cactus_rt::CyclicThreadConfig non_rt_thread_config;
   non_rt_thread_config.SetOtherScheduler(0 /* niceness */);
 

--- a/examples/mutex_example/main.cc
+++ b/examples/mutex_example/main.cc
@@ -21,9 +21,8 @@ class RTThread : public CyclicThread {
   NaiveDoubleBuffer<Data>& buf_;
 
  public:
-  explicit RTThread(cactus_rt::CyclicThreadConfig config, NaiveDoubleBuffer<Data>& buf)
-      : CyclicThread(config
-        ),
+  explicit RTThread(const char* name, cactus_rt::CyclicThreadConfig config, NaiveDoubleBuffer<Data>& buf)
+      : CyclicThread(name, config),
         buf_(buf) {}
 
  protected:
@@ -47,7 +46,8 @@ class NonRTThread : public Thread {
   NaiveDoubleBuffer<Data>& buf_;
 
  public:
-  explicit NonRTThread(cactus_rt::CyclicThreadConfig config, NaiveDoubleBuffer<Data>& buf) : Thread(config), buf_(buf) {}
+  explicit NonRTThread(const char* name, cactus_rt::CyclicThreadConfig config, NaiveDoubleBuffer<Data>& buf)
+      : Thread(name, config), buf_(buf) {}
 
  protected:
   void Run() final {
@@ -70,22 +70,20 @@ void TrivialDemo() {
 
 void ThreadedDemo() {
   cactus_rt::CyclicThreadConfig rt_thread_config;
-  rt_thread_config.name = "RTThread";
   rt_thread_config.period_ns = 1'000'000;
   rt_thread_config.SetFifoScheduler(80 /* priority */);
 
   const cactus_rt::OtherThreadConfig other_config;
 
   cactus_rt::CyclicThreadConfig non_rt_thread_config;
-  non_rt_thread_config.name = "NonRTThread";
   non_rt_thread_config.SetOtherScheduler(0 /* niceness */);
 
   // The double buffer is shared between the two threads, so we pass a reference
   // into the thread and maintain the object lifetime to this function.
   NaiveDoubleBuffer<Data> buf;
 
-  auto rt_thread = std::make_shared<RTThread>(rt_thread_config, buf);
-  auto non_rt_thread = std::make_shared<NonRTThread>(non_rt_thread_config, buf);
+  auto rt_thread = std::make_shared<RTThread>("RTThread", rt_thread_config, buf);
+  auto non_rt_thread = std::make_shared<NonRTThread>("NonRTThread", non_rt_thread_config, buf);
   App  app;
 
   app.RegisterThread(non_rt_thread);

--- a/examples/mutex_example/main.cc
+++ b/examples/mutex_example/main.cc
@@ -69,19 +69,16 @@ void TrivialDemo() {
 }
 
 void ThreadedDemo() {
-  cactus_rt::FifoThreadConfig fifo_config;
-  fifo_config.priority = 80;
-
   cactus_rt::CyclicThreadConfig rt_thread_config;
   rt_thread_config.name = "RTThread";
   rt_thread_config.period_ns = 1'000'000;
-  rt_thread_config.scheduler_config = fifo_config;
+  rt_thread_config.SetFifoScheduler(80 /* priority */);
 
   const cactus_rt::OtherThreadConfig other_config;
 
   cactus_rt::CyclicThreadConfig non_rt_thread_config;
   non_rt_thread_config.name = "NonRTThread";
-  non_rt_thread_config.scheduler_config = other_config;
+  non_rt_thread_config.SetOtherScheduler(0 /* niceness */);
 
   // The double buffer is shared between the two threads, so we pass a reference
   // into the thread and maintain the object lifetime to this function.

--- a/examples/signal_handling_example/main.cc
+++ b/examples/signal_handling_example/main.cc
@@ -12,7 +12,7 @@ class ExampleRTThread : public CyclicThread {
   int64_t loop_counter_ = 0;
 
  public:
-  ExampleRTThread(cactus_rt::CyclicThreadConfig config) : CyclicThread(config) {}
+  ExampleRTThread(const char* name, cactus_rt::CyclicThreadConfig config) : CyclicThread(name, config) {}
 
   int64_t GetLoopCounter() const {
     return loop_counter_;
@@ -27,12 +27,11 @@ class ExampleRTThread : public CyclicThread {
 
 int main() {
   cactus_rt::CyclicThreadConfig config;
-  config.name = "ExampleRTThread";
   config.period_ns = 1'000'000;
   config.cpu_affinity = std::vector<size_t>{2};
   config.SetFifoScheduler(80);
 
-  auto thread = std::make_shared<ExampleRTThread>(config);
+  auto thread = std::make_shared<ExampleRTThread>("ExampleRTThread", config);
   App  app;
 
   app.RegisterThread(thread);

--- a/examples/signal_handling_example/main.cc
+++ b/examples/signal_handling_example/main.cc
@@ -26,14 +26,11 @@ class ExampleRTThread : public CyclicThread {
 };
 
 int main() {
-  cactus_rt::FifoThreadConfig fifo_config;
-  fifo_config.priority = 80;
-
   cactus_rt::CyclicThreadConfig config;
   config.name = "ExampleRTThread";
   config.period_ns = 1'000'000;
   config.cpu_affinity = std::vector<size_t>{2};
-  config.scheduler_config = fifo_config;
+  config.SetFifoScheduler(80);
 
   auto thread = std::make_shared<ExampleRTThread>(config);
   App  app;

--- a/examples/simple_deadline_example/main.cc
+++ b/examples/simple_deadline_example/main.cc
@@ -16,8 +16,7 @@ class ExampleDeadlineThread : public CyclicThread {
   int64_t loop_counter_ = 0;
 
  public:
-  ExampleDeadlineThread(cactus_rt::CyclicThreadConfig config) : CyclicThread(config
-                                                                ) {}
+  ExampleDeadlineThread(const char* name, cactus_rt::CyclicThreadConfig config) : CyclicThread(name, config) {}
 
   int64_t GetLoopCounter() const {
     return loop_counter_;
@@ -33,11 +32,10 @@ class ExampleDeadlineThread : public CyclicThread {
 int main() {
   cactus_rt::CyclicThreadConfig config;
 
-  config.name = "ExampleRTThread";
   config.period_ns = 1'000'000;
   config.SetDeadlineScheduler(500'000 /* runtime */, 1'000'000 /* deadline*/);
 
-  auto thread = std::make_shared<ExampleDeadlineThread>(config);
+  auto thread = std::make_shared<ExampleDeadlineThread>("ExampleRTThread", config);
   App  app;
 
   app.RegisterThread(thread);

--- a/examples/simple_deadline_example/main.cc
+++ b/examples/simple_deadline_example/main.cc
@@ -31,17 +31,12 @@ class ExampleDeadlineThread : public CyclicThread {
 };
 
 int main() {
-  cactus_rt::DeadlineThreadConfig deadline_config;
-  deadline_config.sched_deadline_ns = 1'000'000;
-  deadline_config.sched_runtime_ns = 500'000;
-  deadline_config.sched_period_ns = 1'000'000;
-
   cactus_rt::CyclicThreadConfig config;
+
   config.name = "ExampleRTThread";
+  config.period_ns = 1'000'000;
+  config.SetDeadlineScheduler(500'000 /* runtime */, 1'000'000 /* deadline*/);
 
-  // config.cpu_affinity = std::vector<size_t>{2};
-
-  config.scheduler_config = deadline_config;
   auto thread = std::make_shared<ExampleDeadlineThread>(config);
   App  app;
 

--- a/examples/simple_example/main.cc
+++ b/examples/simple_example/main.cc
@@ -30,16 +30,13 @@ class ExampleRTThread : public CyclicThread {
 };
 
 int main() {
-  cactus_rt::FifoThreadConfig fifo_config;
-  fifo_config.priority = 80;
-
   cactus_rt::CyclicThreadConfig config;
   config.name = "ExampleRTThread";
   config.period_ns = 1'000'000;
   config.cpu_affinity = std::vector<size_t>{2};
-  config.scheduler_config = fifo_config;
+  config.SetFifoScheduler(80);
 
-  auto thread = std::make_shared<ExampleRTThread>(config);
+  auto thread = std::make_shared<ExampleRTThread>(std::move(config));
 
   App app;
   app.StartTraceSession("build/data.perfetto");

--- a/examples/simple_example/main.cc
+++ b/examples/simple_example/main.cc
@@ -13,7 +13,7 @@ class ExampleRTThread : public CyclicThread {
   int64_t loop_counter_ = 0;
 
  public:
-  ExampleRTThread(cactus_rt::CyclicThreadConfig config) : CyclicThread(config) {}
+  ExampleRTThread(const char* name, cactus_rt::CyclicThreadConfig config) : CyclicThread(name, config) {}
 
   int64_t GetLoopCounter() const {
     return loop_counter_;
@@ -31,12 +31,11 @@ class ExampleRTThread : public CyclicThread {
 
 int main() {
   cactus_rt::CyclicThreadConfig config;
-  config.name = "ExampleRTThread";
   config.period_ns = 1'000'000;
   config.cpu_affinity = std::vector<size_t>{2};
   config.SetFifoScheduler(80);
 
-  auto thread = std::make_shared<ExampleRTThread>(std::move(config));
+  auto thread = std::make_shared<ExampleRTThread>("ExampleRTThread", config);
 
   App app;
   app.StartTraceSession("build/data.perfetto");

--- a/examples/tracing_example/main.cc
+++ b/examples/tracing_example/main.cc
@@ -55,13 +55,11 @@ class ExampleRTThread : public CyclicThread {
 };
 
 int main() {
-  cactus_rt::FifoThreadConfig fifo_config;
-  fifo_config.priority = 80;
-
   cactus_rt::CyclicThreadConfig thread_config;
   thread_config.name = "ExampleRTThread";
   thread_config.period_ns = 1'000'000;
-  thread_config.scheduler_config = fifo_config;
+  thread_config.cpu_affinity = std::vector<size_t>{2};
+  thread_config.SetFifoScheduler(80);
 
   cactus_rt::AppConfig app_config;
   app_config.tracer_config.trace_aggregator_cpu_affinity = {1};

--- a/examples/tracing_example/main.cc
+++ b/examples/tracing_example/main.cc
@@ -17,7 +17,7 @@ class ExampleRTThread : public CyclicThread {
   int64_t loop_counter_ = 0;
 
  public:
-  ExampleRTThread(cactus_rt::CyclicThreadConfig config) : CyclicThread(config) {}
+  ExampleRTThread(const char* name, cactus_rt::CyclicThreadConfig config) : CyclicThread(name, config) {}
 
   int64_t GetLoopCounter() const {
     return loop_counter_;
@@ -56,7 +56,6 @@ class ExampleRTThread : public CyclicThread {
 
 int main() {
   cactus_rt::CyclicThreadConfig thread_config;
-  thread_config.name = "ExampleRTThread";
   thread_config.period_ns = 1'000'000;
   thread_config.cpu_affinity = std::vector<size_t>{2};
   thread_config.SetFifoScheduler(80);
@@ -64,7 +63,7 @@ int main() {
   cactus_rt::AppConfig app_config;
   app_config.tracer_config.trace_aggregator_cpu_affinity = {1};
 
-  auto thread = std::make_shared<ExampleRTThread>(thread_config);
+  auto thread = std::make_shared<ExampleRTThread>("ExampleRTThread", thread_config);
   App  app(app_config);
   app.RegisterThread(thread);
 

--- a/include/cactus_rt/config.h
+++ b/include/cactus_rt/config.h
@@ -76,17 +76,16 @@ struct ThreadTracerConfig {
  * @brief The configuration required for a thread
  */
 struct ThreadConfig {
-  // Construct the ThreadConfig. Default scheduler is SCHED_OTHER
-  ThreadConfig() : scheduler(std::make_shared<OtherScheduler>()) {}
-
   // A vector of CPUs this thread should run on. If empty, no CPU restrictions are set.
   std::vector<size_t> cpu_affinity = {};
 
   // The size of the stack for this thread. Defaults to 8MB.
   size_t stack_size = 8 * 1024 * 1024;
 
-  ThreadTracerConfig         tracer_config;
-  std::shared_ptr<Scheduler> scheduler;
+  ThreadTracerConfig tracer_config;
+
+  // The scheduler type, default scheduler is SCHED_OTHER
+  std::shared_ptr<Scheduler> scheduler = std::make_shared<OtherScheduler>();
 
   /**
    * @brief Set the thread scheduler to use the default (non-RT) scheduler

--- a/include/cactus_rt/config.h
+++ b/include/cactus_rt/config.h
@@ -79,9 +79,6 @@ struct ThreadConfig {
   // Construct the ThreadConfig. Default scheduler is SCHED_OTHER
   ThreadConfig() : scheduler(std::make_shared<OtherScheduler>()) {}
 
-  // The name of the thread
-  const char* name = "Thread";
-
   // A vector of CPUs this thread should run on. If empty, no CPU restrictions are set.
   std::vector<size_t> cpu_affinity = {};
 

--- a/include/cactus_rt/cyclic_thread.h
+++ b/include/cactus_rt/cyclic_thread.h
@@ -11,10 +11,13 @@ class CyclicThread : public Thread {
   struct timespec    next_wakeup_time_;
 
  public:
-  CyclicThread(
-    CyclicThreadConfig config
-  ) : Thread(config),
-      period_ns_(config.period_ns) {
+  /**
+   * @brief Create a cyclic thread
+   * @param name The thread name
+   * @param config A cactus_rt::CyclicThreadConfig that specifies configuration parameters for this thread
+   */
+  CyclicThread(const char* name, CyclicThreadConfig config) : Thread(name, config),
+                                                              period_ns_(config.period_ns) {
   }
 
  protected:

--- a/include/cactus_rt/cyclic_thread.h
+++ b/include/cactus_rt/cyclic_thread.h
@@ -6,19 +6,15 @@
 
 namespace cactus_rt {
 class CyclicThread : public Thread {
-  uint64_t        period_ns_;
-  struct timespec next_wakeup_time_;
+  CyclicThreadConfig config_;
+  uint64_t           period_ns_;
+  struct timespec    next_wakeup_time_;
 
  public:
   CyclicThread(
     CyclicThreadConfig config
   ) : Thread(config),
       period_ns_(config.period_ns) {
-    // Set the cyclic thread period to match the deadline period
-    if (std::holds_alternative<DeadlineThreadConfig>(config.scheduler_config)) {
-      auto deadline_config = std::get<DeadlineThreadConfig>(config.scheduler_config);
-      period_ns_ = deadline_config.sched_period_ns;
-    }
   }
 
  protected:

--- a/include/cactus_rt/scheduler.h
+++ b/include/cactus_rt/scheduler.h
@@ -16,7 +16,7 @@ class Scheduler {
 
   virtual void SetSchedAttr() const = 0;
 
-  virtual void Sleep(struct timespec next_wakeup_time) const noexcept = 0;
+  virtual void Sleep(const struct timespec& next_wakeup_time) const noexcept = 0;
 };
 
 class OtherScheduler : public Scheduler {
@@ -37,9 +37,8 @@ class OtherScheduler : public Scheduler {
     }
   }
 
-  void Sleep(struct timespec /* next_wakeup_time */) const noexcept override {
-    // Ignoring return value as man page says "In the Linux implementation, sched_yield() always succeeds."
-    sched_yield();
+  void Sleep(const struct timespec& next_wakeup_time) const noexcept override {
+    clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &next_wakeup_time, nullptr);
   }
 };
 
@@ -62,7 +61,7 @@ class FifoScheduler : public Scheduler {
     }
   }
 
-  void Sleep(struct timespec next_wakeup_time) const noexcept override {
+  void Sleep(const struct timespec& next_wakeup_time) const noexcept override {
     clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &next_wakeup_time, nullptr);
   }
 };
@@ -92,8 +91,9 @@ class DeadlineScheduler : public Scheduler {
     }
   }
 
-  void Sleep(struct timespec next_wakeup_time) const noexcept override {
-    clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &next_wakeup_time, nullptr);
+  void Sleep(const struct timespec& /* next_wakeup_time */) const noexcept override {
+    // Ignoring return value as man page says "In the Linux implementation, sched_yield() always succeeds."
+    sched_yield();
   }
 };
 

--- a/include/cactus_rt/scheduler.h
+++ b/include/cactus_rt/scheduler.h
@@ -1,0 +1,101 @@
+#ifndef CACTUS_RT_SCHEDULER_H_
+#define CACTUS_RT_SCHEDULER_H_
+
+#include <sched.h>
+
+#include <cstring>
+#include <ctime>
+#include <stdexcept>
+
+#include "cactus_rt/linux/sched_ext.h"
+
+namespace cactus_rt {
+class Scheduler {
+ public:
+  virtual ~Scheduler() = default;
+
+  virtual void SetSchedAttr() const = 0;
+
+  virtual void Sleep(struct timespec next_wakeup_time) const noexcept = 0;
+};
+
+class OtherScheduler : public Scheduler {
+ public:
+  int32_t nice = 0;
+
+  void SetSchedAttr() const override {
+    sched_attr attr = {};
+    attr.size = sizeof(attr);
+
+    attr.sched_flags = 0;
+    attr.sched_nice = nice;           // Set the thread niceness
+    attr.sched_policy = SCHED_OTHER;  // Set the scheduler policy
+
+    auto ret = sched_setattr(0, &attr, 0);
+    if (ret < 0) {
+      throw std::runtime_error{std::string("failed to sched_setattr: ") + std::strerror(errno)};
+    }
+  }
+
+  void Sleep(struct timespec /* next_wakeup_time */) const noexcept override {
+    // Ignoring return value as man page says "In the Linux implementation, sched_yield() always succeeds."
+    sched_yield();
+  }
+};
+
+class FifoScheduler : public Scheduler {
+ public:
+  uint32_t priority = 0;
+
+  void SetSchedAttr() const override {
+    sched_attr attr = {};
+    attr.size = sizeof(attr);
+
+    attr.sched_flags = 0;
+    attr.sched_nice = 0;
+    attr.sched_priority = priority;  // Set the scheduler priority
+    attr.sched_policy = SCHED_FIFO;  // Set the scheduler policy
+
+    auto ret = sched_setattr(0, &attr, 0);
+    if (ret < 0) {
+      throw std::runtime_error{std::string("failed to sched_setattr: ") + std::strerror(errno)};
+    }
+  }
+
+  void Sleep(struct timespec next_wakeup_time) const noexcept override {
+    clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &next_wakeup_time, nullptr);
+  }
+};
+
+class DeadlineScheduler : public Scheduler {
+ public:
+  uint64_t sched_runtime_ns;
+  uint64_t sched_deadline_ns;
+  uint64_t sched_period_ns;
+
+  void SetSchedAttr() const override {
+    sched_attr attr = {};
+    attr.size = sizeof(attr);
+
+    attr.sched_flags = 0;
+    attr.sched_nice = 0;
+    attr.sched_priority = 0;  // No priority for SCHED_DEADLINE
+
+    attr.sched_policy = SCHED_DEADLINE;  // Set the scheduler policy
+    attr.sched_runtime = sched_runtime_ns;
+    attr.sched_deadline = sched_deadline_ns;
+    attr.sched_period = sched_period_ns;
+
+    auto ret = sched_setattr(0, &attr, 0);
+    if (ret < 0) {
+      throw std::runtime_error{std::string("failed to sched_setattr: ") + std::strerror(errno)};
+    }
+  }
+
+  void Sleep(struct timespec next_wakeup_time) const noexcept override {
+    clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &next_wakeup_time, nullptr);
+  }
+};
+
+}  // namespace cactus_rt
+#endif

--- a/include/cactus_rt/thread.h
+++ b/include/cactus_rt/thread.h
@@ -21,78 +21,10 @@ using SchedulerConfigVariant = std::variant<OtherThreadConfig, FifoThreadConfig,
 /// @private
 constexpr size_t kDefaultStackSize = 8 * 1024 * 1024;  // 8MB default stack space should be plenty
 
-/**
- * The base thread
- */
-class BaseThread {
-  std::atomic_bool stop_requested_ = false;
-
- public:
-  /**
-   * @brief Return the name of the thread. Mostly used for debug purpose.
-   *
-   * @returns a const renferece to the name string
-   */
-  virtual const std::string& Name() = 0;
-
-  /**
-   * @brief Starts the thread.
-   *
-   * @param start_monotonic_time_ns The start time in the monotonic clock
-   */
-  virtual void Start(int64_t start_monotonic_time_ns) = 0;
-
-  /**
-   * @brief Joins the thread.
-   *
-   * @returns the return value of pthread_join.
-   */
-  virtual int Join() = 0;
-
-  /**
-   * Requests the thread to stop with an atomic.
-   */
-  virtual void RequestStop() noexcept {
-    stop_requested_ = true;
-  }
-
-  // The constructors and destructors are needed because we need to delete
-  // objects of type BaseThread polymorphically, through the map in the App class.
-  BaseThread() = default;
-  virtual ~BaseThread() = default;
-
-  // Copy constructors are not allowed
-  BaseThread(const BaseThread&) = delete;
-  BaseThread& operator=(const BaseThread&) = delete;
-
-  // Should the thread be moveable? std::thread is moveable
-  // TODO: investigate moving the stop_requested_ flag somewhere else
-  // Move constructors are not allowed because of the atomic_bool for now.
-  BaseThread(BaseThread&&) noexcept = delete;
-  BaseThread& operator=(BaseThread&&) noexcept = delete;
-
- protected:
-  /**
-   * @brief Check if stop has been requested
-   *
-   * @return true if stop is requested
-   */
-  bool StopRequested() const noexcept {
-    // Memory order relaxed is OK, because we don't really care when the signal
-    // arrives, we just care that it is arrived at some point.
-    //
-    // Also this could be used in a tight loop so we don't want to waste time when we don't need to.
-    //
-    // https://stackoverflow.com/questions/70581645/why-set-the-stop-flag-using-memory-order-seq-cst-if-you-check-it-with-memory
-    // TODO: possibly use std::stop_source and std::stop_token (C++20)
-    return stop_requested_.load(std::memory_order_relaxed);
-  }
-};
-
 // Necessary forward declaration
 class App;
 
-class Thread : public BaseThread {
+class Thread {
   std::string         name_;
   std::vector<size_t> cpu_affinity_;
   size_t              stack_size_;
@@ -101,6 +33,8 @@ class Thread : public BaseThread {
 
   quill::Logger*                         logger_;
   std::shared_ptr<tracing::ThreadTracer> tracer_;
+
+  std::atomic_bool stop_requested_ = false;
 
   // Non-owning App pointer. Used only for notifying that the thread has
   // started/stopped for tracing purposes.
@@ -134,21 +68,28 @@ class Thread : public BaseThread {
    *
    * @returns The name of the thread.
    */
-  inline const std::string& Name() override { return name_; }
+  inline const std::string& Name() { return name_; }
 
   /**
    * Starts the thread in the background.
    *
    * @param start_monotonic_time_ns should be the start time in nanoseconds for the monotonic clock.
    */
-  void Start(int64_t start_monotonic_time_ns) override;
+  void Start(int64_t start_monotonic_time_ns);
 
   /**
    * Joins the thread.
    *
    * @returns the return value of pthread_join
    */
-  int Join() override;
+  int Join();
+
+  /**
+   * Requests the thread to stop with an atomic.
+   */
+  virtual void RequestStop() noexcept {
+    stop_requested_ = true;
+  }
 
   /**
    * @brief Sets the trace_aggregator_ pointer so the thread can notify the
@@ -159,6 +100,21 @@ class Thread : public BaseThread {
   inline void SetApp(App* app) {
     app_ = app;
   }
+
+  // The constructors and destructors are needed because we need to delete
+  // objects of type Thread polymorphically, through the map in the App class.
+  Thread() = default;
+  virtual ~Thread() = default;
+
+  // Copy constructors are not allowed
+  Thread(const Thread&) = delete;
+  Thread& operator=(const Thread&) = delete;
+
+  // Should the thread be moveable? std::thread is moveable
+  // TODO: investigate moving the stop_requested_ flag somewhere else
+  // Move constructors are not allowed because of the atomic_bool for now.
+  Thread(Thread&&) noexcept = delete;
+  Thread& operator=(Thread&&) noexcept = delete;
 
  protected:
   inline quill::Logger*         Logger() const { return logger_; }
@@ -183,6 +139,22 @@ class Thread : public BaseThread {
    * real-time section.
    */
   virtual void AfterRun() {}
+
+  /**
+   * @brief Check if stop has been requested
+   *
+   * @return true if stop is requested
+   */
+  bool StopRequested() const noexcept {
+    // Memory order relaxed is OK, because we don't really care when the signal
+    // arrives, we just care that it is arrived at some point.
+    //
+    // Also this could be used in a tight loop so we don't want to waste time when we don't need to.
+    //
+    // https://stackoverflow.com/questions/70581645/why-set-the-stop-flag-using-memory-order-seq-cst-if-you-check-it-with-memory
+    // TODO: possibly use std::stop_source and std::stop_token (C++20)
+    return stop_requested_.load(std::memory_order_relaxed);
+  }
 };
 }  // namespace cactus_rt
 

--- a/include/cactus_rt/thread.h
+++ b/include/cactus_rt/thread.h
@@ -80,7 +80,7 @@ class Thread {
    *
    * @returns the return value of pthread_join
    */
-  int Join();
+  int Join() const;
 
   /**
    * Requests the thread to stop with an atomic.

--- a/include/cactus_rt/thread.h
+++ b/include/cactus_rt/thread.h
@@ -50,15 +50,16 @@ class Thread {
   /**
    * Creates a new thread.
    *
+   * @param name The thread name
    * @param config The configuration for the thread
    */
-  Thread(ThreadConfig config)
+  Thread(const char* name, ThreadConfig config)
       : config_(config),
-        name_(config_.name),
+        name_(name),
         cpu_affinity_(config_.cpu_affinity),
         stack_size_(static_cast<size_t>(PTHREAD_STACK_MIN) + config_.stack_size),
         logger_(quill::create_logger(name_)),
-        tracer_(std::make_shared<tracing::ThreadTracer>(config_.name, config_.tracer_config.queue_size)) {}
+        tracer_(std::make_shared<tracing::ThreadTracer>(name, config_.tracer_config.queue_size)) {}
 
   /**
    * Returns the name of the thread

--- a/include/cactus_rt/thread.h
+++ b/include/cactus_rt/thread.h
@@ -59,7 +59,11 @@ class Thread {
         cpu_affinity_(config_.cpu_affinity),
         stack_size_(static_cast<size_t>(PTHREAD_STACK_MIN) + config_.stack_size),
         logger_(quill::create_logger(name_)),
-        tracer_(std::make_shared<tracing::ThreadTracer>(name, config_.tracer_config.queue_size)) {}
+        tracer_(std::make_shared<tracing::ThreadTracer>(name, config_.tracer_config.queue_size)) {
+    if (!config.scheduler) {
+      throw std::runtime_error("ThreadConfig::scheduler cannot be nullptr");
+    }
+  }
 
   /**
    * Returns the name of the thread
@@ -85,7 +89,7 @@ class Thread {
   /**
    * Requests the thread to stop with an atomic.
    */
-  virtual void RequestStop() noexcept {
+  void RequestStop() noexcept {
     stop_requested_ = true;
   }
 
@@ -101,7 +105,6 @@ class Thread {
 
   // The constructors and destructors are needed because we need to delete
   // objects of type Thread polymorphically, through the map in the App class.
-  Thread() = default;
   virtual ~Thread() = default;
 
   // Copy constructors are not allowed

--- a/src/cactus_rt/cyclic_thread.cc
+++ b/src/cactus_rt/cyclic_thread.cc
@@ -1,24 +1,8 @@
 #include "cactus_rt/cyclic_thread.h"
 
+#include "cactus_rt/scheduler.h"
+
 namespace cactus_rt {
-
-namespace {
-void SleepImpl(SchedulerConfigVariant config, timespec next_wakeup_time) {
-  // TODO: maybe track busy wait latency? That feature is not even enabled.
-  // We need to pass in the config to figure out what scheduler type we are using
-  // If we are using SCHED_DEADLINE, we must sched_yield()
-  if (
-    std::holds_alternative<OtherThreadConfig>(config) ||
-    std::holds_alternative<FifoThreadConfig>(config)
-  ) {
-    clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &next_wakeup_time, nullptr);
-
-  } else if (std::holds_alternative<DeadlineThreadConfig>(config)) {
-    // Ignoring return value as man page says "In the Linux implementation, sched_yield() always succeeds."
-    sched_yield();
-  }
-}
-}  // namespace
 
 void CyclicThread::Run() noexcept {
   // TODO: change this from CLOCK_MONOTONIC to CLOCK_MONOTONIC_RAW/CLOCK_BOOTTIME?
@@ -47,7 +31,8 @@ void CyclicThread::Run() noexcept {
     TrackLatency(wakeup_latency, loop_latency);
 
     next_wakeup_time_ = AddTimespecByNs(next_wakeup_time_, static_cast<int64_t>(period_ns_));
-    SleepImpl(SchedulerConfig(), next_wakeup_time_);
+    // TODO: maybe track busy wait latency? That feature is not even enabled.
+    this->Config().scheduler->Sleep(next_wakeup_time_);
   }
 }
 }  // namespace cactus_rt

--- a/src/cactus_rt/thread.cc
+++ b/src/cactus_rt/thread.cc
@@ -9,57 +9,14 @@
 #include <stdexcept>
 
 #include "cactus_rt/app.h"
+#include "cactus_rt/config.h"
 #include "cactus_rt/linux/sched_ext.h"
 
 namespace cactus_rt {
 
-namespace {
-// TODO: Pass thread config instead of CPU affinity
-void SetSchedAttr(const SchedulerConfigVariant& config_variant, const std::vector<size_t>& cpu_affinity) {
-  // Populate sched_attr based on the type of scheduler config provided
-  sched_attr attr = {};
-  attr.size = sizeof(attr);
-
-  if (std::holds_alternative<OtherThreadConfig>(config_variant)) {
-    auto config = std::get<OtherThreadConfig>(config_variant);
-
-    attr.sched_flags = 0;
-    attr.sched_nice = config.nice;    // Set the thread niceness
-    attr.sched_policy = SCHED_OTHER;  // Set the scheduler policy
-  } else if (std::holds_alternative<FifoThreadConfig>(config_variant)) {
-    auto config = std::get<FifoThreadConfig>(config_variant);
-
-    attr.sched_flags = 0;
-    attr.sched_nice = 0;
-    attr.sched_priority = config.priority;  // Set the scheduler priority
-    attr.sched_policy = SCHED_FIFO;         // Set the scheduler policy
-  } else if (std::holds_alternative<DeadlineThreadConfig>(config_variant)) {
-    if (!cpu_affinity.empty()) {
-      throw std::runtime_error{"SCHED_DEADLINE cannot be used with cpu affinity, see sched_setattr(2)"};
-    }
-
-    auto config = std::get<DeadlineThreadConfig>(config_variant);
-
-    attr.sched_flags = 0;
-    attr.sched_nice = 0;
-    attr.sched_priority = 0;  // No priority for SCHED_DEADLINE
-
-    attr.sched_policy = SCHED_DEADLINE;  // Set the scheduler policy
-    attr.sched_runtime = config.sched_runtime_ns;
-    attr.sched_deadline = config.sched_deadline_ns;
-    attr.sched_period = config.sched_period_ns;
-  }
-
-  auto ret = sched_setattr(0, &attr, 0);
-  if (ret < 0) {
-    throw std::runtime_error{std::string("failed to sched_setattr: ") + std::strerror(errno)};
-  }
-}
-}  // namespace
-
 void* Thread::RunThread(void* data) {
   auto* thread = static_cast<Thread*>(data);
-  SetSchedAttr(thread->scheduler_config_, thread->cpu_affinity_);
+  thread->config_.scheduler->SetSchedAttr();
 
   thread->tracer_->SetTid();
   if (thread->app_ != nullptr) {

--- a/src/cactus_rt/thread.cc
+++ b/src/cactus_rt/thread.cc
@@ -75,7 +75,7 @@ void Thread::Start(int64_t start_monotonic_time_ns) {
   }
 }
 
-int Thread::Join() {
+int Thread::Join() const {
   return pthread_join(thread_, nullptr);
 }
 }  // namespace cactus_rt


### PR DESCRIPTION
- Merge `BaseThread` into `Thread` (Resolves #46)
- Move thread name into constructor (Resolves #55)
- Remove the `SchedulerVariant` in favour of a `shared_ptr<Scheduler>`