### PR TITLE
Added ability to turn some builtin tracing events off

### DIFF
--- a/examples/tracing_example/main.cc
+++ b/examples/tracing_example/main.cc
@@ -34,6 +34,12 @@ class ExampleRTThread : public CyclicThread {
     Plan();
     Act();
 
+    // Cause an overrun every 1.5s to demonstrate the overrun detection and marking feature.
+    if (loop_counter_ % 1500 == 0) {
+      auto span = Tracer().WithSpan("RogueSegment", "app");
+      WasteTime(std::chrono::microseconds(1200));
+    }
+
     return false;
   }
 
@@ -59,6 +65,8 @@ int main() {
   thread_config.period_ns = 1'000'000;
   thread_config.cpu_affinity = std::vector<size_t>{2};
   thread_config.SetFifoScheduler(80);
+
+  thread_config.tracer_config.trace_sleep = true;
 
   cactus_rt::AppConfig app_config;
   app_config.tracer_config.trace_aggregator_cpu_affinity = {1};

--- a/include/cactus_rt/app.h
+++ b/include/cactus_rt/app.h
@@ -1,6 +1,8 @@
 #ifndef CACTUS_RT_APP_H_
 #define CACTUS_RT_APP_H_
 
+#include <gtest/gtest_prod.h>
+
 #include <list>
 #include <memory>
 #include <vector>
@@ -18,6 +20,7 @@ namespace cactus_rt {
  */
 class App {
   friend class Thread;
+  FRIEND_TEST(SingleThreadTracingTest, QueueOverflowWillNotBlock);
 
   // The name of the app
   const char* name_;

--- a/include/cactus_rt/config.h
+++ b/include/cactus_rt/config.h
@@ -64,7 +64,33 @@ struct DeadlineThreadConfig {
 };
 
 struct ThreadTracerConfig {
+  /**
+   * @brief The size of the queue for the trace events for this thread.
+   *
+   * If the number of trace event overflows
+   */
   uint32_t queue_size = 16384;
+
+  /**
+   * @brief Automatically trace the Loop function in CyclicThread.
+   *
+   * Enabling this will cause a slight performance overhead when trace session is started.
+   */
+  bool trace_loop = true;
+
+  /**
+   * @brief Automatically emit an event if the Loop function takes longer than the period.
+   *
+   * Enabling this will cause a slight performance overhead when trace session is started.
+   */
+  bool trace_overrun = true;
+
+  /**
+   * @brief Automatically trace the Sleep function in CyclicThread.
+   *
+   * Enabling this will cause a slight performance overhead when trace session is started.
+   */
+  bool trace_sleep = false;
 };
 
 /**

--- a/include/cactus_rt/cyclic_thread.h
+++ b/include/cactus_rt/cyclic_thread.h
@@ -6,9 +6,8 @@
 
 namespace cactus_rt {
 class CyclicThread : public Thread {
-  CyclicThreadConfig config_;
-  uint64_t           period_ns_;
-  struct timespec    next_wakeup_time_;
+  uint64_t        period_ns_;
+  struct timespec next_wakeup_time_;
 
  public:
   /**
@@ -37,16 +36,6 @@ class CyclicThread : public Thread {
    * @param loop_latency the latency of Loop() call in us.
    */
   virtual void TrackLatency(int64_t /*wakeup_latency*/, int64_t /*loop_latency*/) noexcept {}
-
-  /**
-   * @brief This function is called before each loop iteration. It is intended to act as a trace point.
-   */
-  virtual void TraceLoopStart() noexcept {}
-
-  /**
-   * @brief This function is called after each loop iteration. It is intended to act as a trace point.
-   */
-  virtual void TraceLoopEnd() noexcept {}
 };
 
 }  // namespace cactus_rt

--- a/include/cactus_rt/thread.h
+++ b/include/cactus_rt/thread.h
@@ -121,7 +121,7 @@ class Thread {
   inline quill::Logger*         Logger() const { return logger_; }
   inline tracing::ThreadTracer& Tracer() { return *tracer_; }
   inline int64_t                StartMonotonicTimeNs() const { return start_monotonic_time_ns_; }
-  inline const ThreadConfig&    Config() const { return config_; }
+  inline const ThreadConfig&    Config() const noexcept { return config_; }
 
   /**
    * Override this method to do work. If this is a real-time thread, once this
@@ -146,7 +146,7 @@ class Thread {
    *
    * @return true if stop is requested
    */
-  bool StopRequested() const noexcept {
+  inline bool StopRequested() const noexcept {
     // Memory order relaxed is OK, because we don't really care when the signal
     // arrives, we just care that it is arrived at some point.
     //

--- a/include/cactus_rt/tracing/thread_tracer.disabled.h
+++ b/include/cactus_rt/tracing/thread_tracer.disabled.h
@@ -56,7 +56,7 @@ class ThreadTracer {
     return false;
   }
 
-  TraceSpan WithSpan(const char* /* name */, const char* /* category */ = nullptr) noexcept {
+  TraceSpan WithSpan(const char* /* name */, const char* /* category */ = nullptr, bool /* enabled */ = true) noexcept {
     TraceSpan span;
     return span;
   }

--- a/include/cactus_rt/tracing/thread_tracer.h
+++ b/include/cactus_rt/tracing/thread_tracer.h
@@ -62,7 +62,7 @@ class ThreadTracer {
 
   bool      StartSpan(const char* name, const char* category = nullptr) noexcept;
   bool      EndSpan() noexcept;
-  TraceSpan WithSpan(const char* name, const char* category = nullptr) noexcept;
+  TraceSpan WithSpan(const char* name, const char* category = nullptr, bool enabled = true) noexcept;
   bool      InstantEvent(const char* name, const char* category = nullptr) noexcept;
 
   inline EventCountData EventCount() const noexcept { return event_count_.Read(); }
@@ -87,7 +87,7 @@ class TraceSpan {
   friend class ThreadTracer;
   ThreadTracer* thread_tracer_;
 
-  TraceSpan(ThreadTracer* tracer, const char* name, const char* category = nullptr);
+  TraceSpan(ThreadTracer* tracer, const char* name, const char* category = nullptr, bool enabled = true);
 
  public:
   ~TraceSpan();

--- a/src/cactus_rt/cyclic_thread.cc
+++ b/src/cactus_rt/cyclic_thread.cc
@@ -29,6 +29,14 @@ void CyclicThread::Run() noexcept {
 
     if (tracer_config.trace_overrun && static_cast<uint64_t>(loop_latency) >= period_ns_) {
       Tracer().InstantEvent("CyclicThread::LoopOverrun", "cactusrt");
+
+      LOG_WARNING_LIMIT(
+        std::chrono::milliseconds(100),
+        this->Logger(),
+        "At least 1 loop overrun detected in the last 100ms: latency ({}ns) > period ({}ns)",
+        loop_latency,
+        period_ns_
+      );
     }
 
     if (should_stop) {

--- a/src/cactus_rt/tracing/thread_tracer.cc
+++ b/src/cactus_rt/tracing/thread_tracer.cc
@@ -62,8 +62,8 @@ bool ThreadTracer::InstantEvent(const char* name, const char* category) noexcept
   return false;
 }
 
-TraceSpan ThreadTracer::WithSpan(const char* name, const char* category) noexcept {
-  TraceSpan span(this, name, category);
+TraceSpan ThreadTracer::WithSpan(const char* name, const char* category, bool enabled) noexcept {
+  TraceSpan span(this, name, category, enabled);
   return span;
 }
 
@@ -92,14 +92,13 @@ void ThreadTracer::IncrementEventCount(bool dropped) noexcept {
   });
 }
 
-TraceSpan::TraceSpan(ThreadTracer* tracer, const char* name, const char* category) : thread_tracer_(tracer) {
-  thread_tracer_->StartSpan(name, category);
+TraceSpan::TraceSpan(ThreadTracer* tracer, const char* name, const char* category, bool enabled) : thread_tracer_(enabled ? tracer : nullptr) {
+  if (thread_tracer_ != nullptr) {
+    thread_tracer_->StartSpan(name, category);
+  }
 }
 
 TraceSpan::~TraceSpan() {
-  // TODO: is it possible for thread_tracer_ to be nullptr? Maybe when the move
-  // constructor happens? It's hard to save. Need to check.
-  // Wouldn't there also be a data race if thread_tracer_ can potentially change?
   if (thread_tracer_ != nullptr) {
     thread_tracer_->EndSpan();
   }

--- a/tests/tracing/helpers/mock_threads.h
+++ b/tests/tracing/helpers/mock_threads.h
@@ -33,17 +33,18 @@ class MockRegularThread : public cactus_rt::Thread {
 };
 
 class MockCyclicThread : public cactus_rt::CyclicThread {
-  static cactus_rt::CyclicThreadConfig MakeConfig();
+  static cactus_rt::CyclicThreadConfig MakeConfig(cactus_rt::ThreadTracerConfig tracer_config);
 
-  int64_t                   iterations_executed_ = 0;
-  int64_t                   num_iterations_;
-  std::chrono::microseconds time_per_iteration_;
+  int64_t                      iterations_executed_ = 0;
+  std::function<void(int64_t)> custom_loop_func_;
+  int64_t                      num_iterations_;
 
  public:
   MockCyclicThread(
-    const char*               name = kCyclicThreadName,
-    int64_t                   num_iterations = 20,  // 200ms execution, which is good enough for testing.
-    std::chrono::microseconds time_per_iteration = std::chrono::microseconds(1000)
+    const char*                   name = kCyclicThreadName,
+    cactus_rt::ThreadTracerConfig tracer_config = {},
+    std::function<void(int64_t)>  custom_loop_func = {},
+    int64_t                       num_iterations = 20  // 200ms execution, which is good enough for testing.
   );
 
  protected:

--- a/tests/tracing/multi_threaded_test.cc
+++ b/tests/tracing/multi_threaded_test.cc
@@ -13,6 +13,8 @@ namespace {
 const char* kAppName = "TestApp";
 }
 
+namespace cactus_rt {
+
 class MultiThreadTracingTest : public ::testing::Test {
   static cactus_rt::AppConfig CreateAppConfig() {
     cactus_rt::AppConfig config;
@@ -131,3 +133,5 @@ TEST_F(MultiThreadTracingTest, CyclicThreadTracesLoop) {
     AssertIsTrackEventSliceEnd(*packets[end_idx], thread_track_uuid, sequence_id);
   }
 }
+
+}  // namespace cactus_rt

--- a/tests/tracing/single_threaded_test.cc
+++ b/tests/tracing/single_threaded_test.cc
@@ -13,6 +13,8 @@ namespace {
 const char* kAppName = "TestApp";
 }
 
+namespace cactus_rt {
+
 class SingleThreadTracingTest : public ::testing::Test {
   static cactus_rt::AppConfig CreateAppConfig() {
     cactus_rt::AppConfig config;
@@ -264,6 +266,9 @@ TEST_F(SingleThreadTracingTest, DynamicallyAddingSinkWillWork) {
 }
 
 TEST_F(SingleThreadTracingTest, QueueOverflowWillNotBlock) {
+  // To make the queue overflow, we intentionally stop the TraceAggregator
+  app_.StopTraceAggregator();
+
   // Fill the queue
   regular_thread_->RunOneIteration([](MockRegularThread* self) {
     for (size_t i = 0; i < self->TracerForTest().QueueCapacity(); ++i) {
@@ -286,3 +291,5 @@ TEST_F(SingleThreadTracingTest, TraceAggregatorCPUAffinity) {
 TEST_F(SingleThreadTracingTest, CorrectlyHandleSinkWriterFailure) {
   GTEST_SKIP() << "TODO";
 }
+
+}  // namespace cactus_rt


### PR DESCRIPTION
CyclicThread::Loop, CyclicThread::Sleep can be selectively turned on and off for tracing.

Also added ability to trace the CyclicThread::Sleep and also send InstantEvent if the Loop overruns, which allows for easier visualization.

Fixes #45 

TODO:

- [x] Test instant event
- [x] Test turning on off stuff
- [ ] Investigate variant instead of the nullptr trick for performance.