### PR TITLE
refactor: trace aggregator cleanup

### DIFF
--- a/include/cactus_rt/tracing/trace_aggregator.h
+++ b/include/cactus_rt/tracing/trace_aggregator.h
@@ -104,6 +104,9 @@ class TraceAggregator {
 
   void SetupCPUAffinityIfNecessary() const;
 
+  size_t TryDequeueOnceFromAllTracers(Trace& trace) noexcept;
+  void   WriteTrace(const Trace& trace) noexcept;
+
   Trace CreateProcessDescriptorPacket() const;
   Trace CreateThreadDescriptorPacket(const ThreadTracer& thread_tracer) const;
   void  AddTrackEventPacketToTrace(Trace& trace, const ThreadTracer& thread_tracer, const TrackEventInternal& track_event_internal) const;

--- a/tests/tracing/tracing_benchmark.cc
+++ b/tests/tracing/tracing_benchmark.cc
@@ -20,7 +20,7 @@ void BM_ThreadTracerWithSpanEnabledWithCategory(benchmark::State& state) {
   cactus_rt::tracing::EnableTracing();
   cactus_rt::tracing::ThreadTracer thread_tracer("benchmark_tracer", kQueueSize);
   for (auto _ : state) {
-    thread_tracer.WithSpan("EventName", "category");
+    benchmark::DoNotOptimize(thread_tracer.WithSpan("EventName", "category"));
   }
 }
 BENCHMARK(BM_ThreadTracerWithSpanEnabledWithCategory)->Iterations(kQueueSize / 2);


### PR DESCRIPTION
Made the code a bit more DRY. This makes the code a bit more clear and less error prone (previously we had a data race on tracers_ and sinks_ due to the lack of a lock, which is the lock that protects tracer/sink registration, not the actual event dequeue).

This sets up a future where the trace aggregator can be refactored to write out to a bigger in-memory cache before batching the IO writes.

Related: #38 