### PR TITLE
Added -fPIC target compile option to enable downstream linking by shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,8 @@ function(setup_cactus_rt_target_options target_name)
     -Wdouble-promotion
     -Wformat=2
     -Wimplicit-fallthrough
+
+    -fPIC
   )
 
   target_compile_features(${target_name}


### PR DESCRIPTION
I get an issue linking a shared library with the static target provided by this project. My compiler suggested recompiling `cactus_rt` with the `-fPIC` option, and it subsequently builds and works correctly. [Here is the GCC documentation](https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#index-fpic) about the option for reference