### PR TITLE
Set thread name with pthread API

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
   "recommendations": [
     "ms-vscode.cpptools",
-    "llvm-vs-code-extensions.vscode-clangd"
+    "llvm-vs-code-extensions.vscode-clangd",
+    "cschlosser.doxdocgen"
   ]
 }

--- a/src/cactus_rt/thread.cc
+++ b/src/cactus_rt/thread.cc
@@ -17,6 +17,8 @@ void* Thread::RunThread(void* data) {
   auto* thread = static_cast<Thread*>(data);
   thread->config_.scheduler->SetSchedAttr();
 
+  pthread_setname_np(pthread_self(), thread->name_.c_str());
+
   thread->tracer_ = std::make_shared<tracing::ThreadTracer>(thread->name_, thread->config_.tracer_config.queue_size);
   thread->tracer_->SetTid();
 


### PR DESCRIPTION
Fixes #94

It works:

![image](https://github.com/user-attachments/assets/26c295d9-09fb-47fa-90e4-ed82ca46422f)
