### PR TITLE
Fixed clangd in ROS workspace.

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,9 +1,0 @@
----
-CompileFlags:
-  CompilationDatabase: build/debug
----
-If:
-  PathMatch: tests/.*
-
-CompileFlags:
-  CompilationDatabase: build/test

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,8 @@
   "editor.formatOnSave": true,
   "[cpp]": {
     "editor.defaultFormatter": "llvm-vs-code-extensions.vscode-clangd"
-  }
+  },
+  "clangd.arguments": [
+    "--compile-commands-dir=${workspaceFolder}/build/debug"
+  ]
 }


### PR DESCRIPTION
Adding a .clangd file in the root of the repo causes it to be used even if cactus-rt is developed as a part of a ROS package, which causes clangd to not show the appropriate completion data. By moving it into a vscode config, we get around this problem for now.

Fixes #96 