### PR TITLE
Signal handling with ROS2

### DIFF
--- a/examples/ros2/publisher/simple_data.cc
+++ b/examples/ros2/publisher/simple_data.cc
@@ -53,15 +53,13 @@ class RTROS2PublisherThread : public cactus_rt::CyclicThread, public cactus_rt::
   }
 };
 
-int main(int argc, char* argv[]) {
-  rclcpp::init(argc, argv);
-
+int main(int argc, const char* argv[]) {
   const cactus_rt::AppConfig app_config;
 
   cactus_rt::ros2::Ros2Adapter::Config ros2_adapter_config;
   ros2_adapter_config.timer_interval = std::chrono::milliseconds(50);
 
-  cactus_rt::ros2::App app("SimpleDataROS2Publisher", app_config, ros2_adapter_config);
+  cactus_rt::ros2::App app(argc, argv, "SimpleDataROS2Publisher", app_config, ros2_adapter_config);
   app.StartTraceSession("build/publisher.perfetto");
 
   constexpr std::chrono::seconds time(30);
@@ -72,9 +70,12 @@ int main(int argc, char* argv[]) {
 
   app.Start();
 
-  std::this_thread::sleep_for(time);
+  std::thread t([&app, &time]() {
+    std::this_thread::sleep_for(time);
+    app.RequestStop();
+  });
+  t.detach();
 
-  app.RequestStop();
   app.Join();
 
   std::cout << "Done\n";

--- a/examples/ros2/subscriber/complex_data.cc
+++ b/examples/ros2/subscriber/complex_data.cc
@@ -78,10 +78,8 @@ class RTROS2SubscriberThread : public cactus_rt::CyclicThread, public cactus_rt:
   }
 };
 
-int main(int argc, char* argv[]) {
-  rclcpp::init(argc, argv);
-
-  cactus_rt::ros2::App app("SimpleDataROS2Subscriber");
+int main(int argc, const char* argv[]) {
+  cactus_rt::ros2::App app(argc, argv, "SimpleDataROS2Subscriber");
   app.StartTraceSession("build/subscriber.perfetto");
 
   constexpr std::chrono::seconds time(30);
@@ -92,9 +90,12 @@ int main(int argc, char* argv[]) {
 
   app.Start();
 
-  std::this_thread::sleep_for(time);
+  std::thread t([&app, &time]() {
+    std::this_thread::sleep_for(time);
+    app.RequestStop();
+  });
+  t.detach();
 
-  app.RequestStop();
   app.Join();
 
   std::cout << "Done\n";

--- a/examples/ros2/subscriber/simple_data.cc
+++ b/examples/ros2/subscriber/simple_data.cc
@@ -53,10 +53,8 @@ class RTROS2SubscriberThread : public cactus_rt::CyclicThread, public cactus_rt:
   }
 };
 
-int main(int argc, char* argv[]) {
-  rclcpp::init(argc, argv);
-
-  cactus_rt::ros2::App app("SimpleDataROS2Subscriber");
+int main(int argc, const char* argv[]) {
+  cactus_rt::ros2::App app(argc, argv, "SimpleDataROS2Subscriber");
   app.StartTraceSession("build/subscriber.perfetto");
 
   constexpr std::chrono::seconds time(30);
@@ -67,9 +65,12 @@ int main(int argc, char* argv[]) {
 
   app.Start();
 
-  std::this_thread::sleep_for(time);
+  std::thread t([&app, &time]() {
+    std::this_thread::sleep_for(time);
+    app.RequestStop();
+  });
+  t.detach();
 
-  app.RequestStop();
   app.Join();
 
   std::cout << "Done\n";

--- a/include/cactus_rt/ros2/app.h
+++ b/include/cactus_rt/ros2/app.h
@@ -41,15 +41,22 @@ class Ros2ExecutorThread : public cactus_rt::Thread, public cactus_rt::ros2::Ros
 };
 
 class App : public cactus_rt::App {
-  std::shared_ptr<Ros2Adapter>        ros2_adapter_;
+  std::shared_ptr<Ros2Adapter> ros2_adapter_;
+
   std::shared_ptr<Ros2ExecutorThread> ros2_executor_thread_;
 
+  std::thread signal_handling_thread_;
+
  public:
-  explicit App(
+  App(
+    int                  argc,
+    const char*          argv[],  // NOLINT
     std::string          name = "RTROS2App",
     cactus_rt::AppConfig config = cactus_rt::AppConfig(),
     Ros2Adapter::Config  ros2_adapter_config = Ros2Adapter::Config()
   );
+
+  ~App() override;
 
   template <typename ThreadT, typename... Args>
   std::shared_ptr<ThreadT> CreateROS2EnabledThread(Args&&... args) {

--- a/include/cactus_rt/signal_handler.h
+++ b/include/cactus_rt/signal_handler.h
@@ -6,8 +6,6 @@
 #include <csignal>
 #include <vector>
 
-#include "app.h"
-
 /// Namespace comment is needed for doxygen to generate cross references correctly.
 namespace cactus_rt {
 /**

--- a/src/cactus_rt/signal_handler.cc
+++ b/src/cactus_rt/signal_handler.cc
@@ -4,6 +4,8 @@
 
 #include <atomic>
 #include <cstring>
+#include <stdexcept>
+#include <string>
 
 namespace cactus_rt {
 /// @private


### PR DESCRIPTION
Takes over signal handling in `cactus_rt::ros2::App` by taking over `rclcpp::init` and `rclcpp::shutdown`. This is necessary as rclcpp automatically handles signals otherwise and the signals will not propagate to cactus-rt threads.

Fixes #92.