### PR TITLE
Add proper header to signal_handler.cc

### DIFF
--- a/src/cactus_rt/signal_handler.cc
+++ b/src/cactus_rt/signal_handler.cc
@@ -6,6 +6,7 @@
 #include <cstring>
 #include <stdexcept>
 #include <string>
+#include <tuple>
 
 namespace cactus_rt {
 /// @private


### PR DESCRIPTION
Fixes #117

std::ignore requires either utility or tuple. With utility, clangd complains that it's not being used, so I guess tuple is the right one.