### PR TITLE
fix ROS2 integration

### DIFF
--- a/include/cactus_rt/ros2/app.h
+++ b/include/cactus_rt/ros2/app.h
@@ -69,8 +69,6 @@ class App : public cactus_rt::App {
     return thread;
   }
 
-  void Start(int64_t start_monotonic_time_ns = -1) override;
-
   void RequestStop() override;
 
   void Join() override;

--- a/src/cactus_rt/ros2/app.cc
+++ b/src/cactus_rt/ros2/app.cc
@@ -4,7 +4,6 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include "cactus_rt/signal_handler.h"
-#include "cactus_rt/utils.h"
 
 namespace cactus_rt::ros2 {
 
@@ -58,16 +57,6 @@ App::App(
 
 App::~App() {
   rclcpp::shutdown();
-}
-
-void App::Start(int64_t start_monotonic_time_ns) {
-  // Start the Ros2ExecutorThread first. Don't think it is 100% necessary but why not get a head start.
-  if (start_monotonic_time_ns == -1) {
-    start_monotonic_time_ns = NowNs();
-  }
-
-  ros2_executor_thread_->Start(start_monotonic_time_ns);
-  cactus_rt::App::Start(start_monotonic_time_ns);
 }
 
 void App::RequestStop() {


### PR DESCRIPTION
With App::CreateThread, we are automatically registering every thread. This means we shouldn't be manually starting Ros2ExecutorThread anymore.