### PR TITLE
fix duplicate header guards

### DIFF
--- a/include/cactus_rt/tracing/sink.disabled.h
+++ b/include/cactus_rt/tracing/sink.disabled.h
@@ -1,5 +1,5 @@
-#ifndef CACTUS_RT_TRACING_SINK_H_
-#define CACTUS_RT_TRACING_SINK_H_
+#ifndef CACTUS_RT_TRACING_SINK_DISABLED_H_
+#define CACTUS_RT_TRACING_SINK_DISABLED_H_
 
 namespace cactus_rt::tracing {
 class Sink {


### PR DESCRIPTION
`sink.h` and `sink.disabled.h` have identical header guards, because of which I couldn't build my project with cactus-rt linked.

This was the only issue and the build then succeeded as expected. 

As the `CACTUS_RT_TRACING_ENABLED` compiler option is set by default, these header should not be included. I'm not sure why the compiler then went ahead and looked for required definitions in ALL headers, even those that should not be included - I'm a bit out of my depth here.

Anyways, now it works for me and is synchronized with how the rest of the header guards in `include/tracing` are defined.

Byeee